### PR TITLE
wire joy into the nox terrain

### DIFF
--- a/src/import/structurize.rs
+++ b/src/import/structurize.rs
@@ -384,7 +384,7 @@ fn find_merge(then_target: u32, else_target: u32, succs: &BTreeMap<u32, Vec<u32>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mir_format::{MirBlock, MirOperand, MirConstValue, MirPlace, MirTerminator};
+    use mir_format::{MirBlock, MirOperand, MirConstValue, MirTerminator};
 
     fn linear_blocks() -> Vec<MirBlock> {
         vec![

--- a/vm/nox/target.toml
+++ b/vm/nox/target.toml
@@ -23,7 +23,8 @@ spill_ram_base = 0
 
 [hash]
 function = "Hemera"
-digest_width = 8
+# nox hash emits a 4-element truncated digest (patterns/hash.rs); rate stays 8
+digest_width = 4
 rate = 8
 
 [extension_field]
@@ -31,6 +32,12 @@ degree = 3
 
 [cost]
 tables = ["reductions"]
+
+[warrior]
+name = "joy"
+crate = "joy"
+runner = true
+prover = false   # flip in M4 when joy prove emits zheng proofs
 
 [status]
 level = 3


### PR DESCRIPTION
Applies joy/.claude/trident-wiring.md: [warrior] section in vm/nox/target.toml (runner=true, prover flips in M4); digest_width corrected 8→4 to match nox patterns/hash.rs (4-element truncated digest); two unused MirPlace imports dropped (the only --tests warnings). 1041 tests green.