### PR TITLE
feat: struct-field & array-element assignment through the front end

### DIFF
--- a/src/api/tests/features.rs
+++ b/src/api/tests/features.rs
@@ -273,3 +273,47 @@ fn test_pure_fn_compiles() {
     assert!(result.is_ok(), "pure fn should compile: {:?}", result.err());
 }
 
+
+#[test]
+fn test_struct_field_assignment_compiles_triton() {
+    // p.x = v — struct field assignment must reach codegen (was rejected by
+    // the mutability checker as "immutable"). Verify it compiles to TASM
+    // with no error marker and a real store (swap/pop), not a silent no-op.
+    let source = "program test\nstruct Point { x: Field, y: Field }\nfn main() {\n    let mut p = Point { x: pub_read(), y: pub_read() }\n    p.x = 42\n    pub_write(p.x)\n    pub_write(p.y)\n}";
+    let result = compile(source, "test.tri");
+    assert!(
+        result.is_ok(),
+        "struct field assignment should compile for triton: {:?}",
+        result.err()
+    );
+    let tasm = result.unwrap();
+    assert!(!tasm.contains("ERROR"), "no error marker: {}", tasm);
+    assert!(tasm.contains("swap"), "field store emits a swap");
+}
+
+#[test]
+fn test_array_element_assignment_compiles_triton() {
+    // a[i] = v — array element assignment used to collapse to Place::Var("_error_").
+    let source = "program test\nfn main() {\n    let mut a: [Field; 3] = [pub_read(), pub_read(), pub_read()]\n    a[1] = 99\n    pub_write(a[0])\n    pub_write(a[1])\n    pub_write(a[2])\n}";
+    let result = compile(source, "test.tri");
+    assert!(
+        result.is_ok(),
+        "array element assignment should compile for triton: {:?}",
+        result.err()
+    );
+    let tasm = result.unwrap();
+    assert!(!tasm.contains("ERROR"), "no error marker: {}", tasm);
+    assert!(tasm.contains("swap"), "element store emits a swap");
+}
+
+#[test]
+fn test_field_and_index_assignment_immutable_still_rejected() {
+    // Mutability is still enforced through the field path: assigning a field
+    // of an immutable binding must error.
+    let source = "program test\nstruct Point { x: Field, y: Field }\nfn main() {\n    let p = Point { x: 1, y: 2 }\n    p.x = 5\n    pub_write(p.x)\n}";
+    let result = compile(source, "test.tri");
+    assert!(
+        result.is_err(),
+        "assigning a field of an immutable struct must be rejected"
+    );
+}

--- a/src/ir/tir/builder/stmt.rs
+++ b/src/ir/tir/builder/stmt.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeMap;
 
 use crate::ast::*;
+use crate::span::Spanned;
 use crate::tir::TIROp;
 
 use super::layout::resolve_type_width;
@@ -16,6 +17,206 @@ use super::TIRBuilder;
 // ─── Block and statement emission ─────────────────────────────────
 
 impl TIRBuilder {
+    /// Lower an assignment `place = value` on the stack machine.
+    ///
+    /// Handles three place forms produced by the parser:
+    /// - simple variable `x`
+    /// - dotted struct field `p.x` / `p.q.r` (a dotted `Place::Var`)
+    /// - array/struct element `a[i]` (a `Place::Index`), constant index
+    ///
+    /// Each writes a single-word slot in place (evaluate the value, then
+    /// `swap`/`pop` it into the target slot). Multi-word field/element writes
+    /// and runtime array indices are not yet supported on the stack machine and
+    /// emit an explicit error rather than miscompiling.
+    pub(crate) fn build_assign(&mut self, place: &Place, value: &Expr) {
+        match place {
+            Place::Var(name) if !name.contains('.') => {
+                // Simple variable reassignment (width-1 slot).
+                self.build_expr(value);
+                let depth = self.stack.access_var(name);
+                self.flush_stack_effects();
+                self.store_top_into(depth);
+                self.stack.pop();
+            }
+            // Dotted field access `p.x` — the parser encodes this as a dotted
+            // Place::Var; a structured FieldAccess reduces to the same store.
+            Place::Var(name) => {
+                self.build_dotted_field_store(name, value);
+            }
+            Place::FieldAccess(inner, field) => {
+                // Flatten a structured field-access place into a dotted name
+                // when the base is a (possibly dotted) variable.
+                if let Some(base) = Self::place_dotted_name(inner) {
+                    let full = format!("{}.{}", base, field.node);
+                    self.build_dotted_field_store(&full, value);
+                } else {
+                    self.build_expr(value);
+                    self.ops.push(TIROp::Comment(
+                        "ERROR: unsupported field-assignment target".to_string(),
+                    ));
+                    self.ops.push(TIROp::Pop(1));
+                    self.stack.pop();
+                }
+            }
+            Place::Index(inner, index) => {
+                self.build_index_store(inner, index, value);
+            }
+        }
+    }
+
+    /// Store the single word on top of the stack into the slot at `depth`
+    /// (measured from the current top, with the value already pushed).
+    fn store_top_into(&mut self, depth: u32) {
+        if depth <= 15 {
+            self.ops.push(TIROp::Swap(depth));
+            self.ops.push(TIROp::Pop(1));
+        } else {
+            self.ops.push(TIROp::Comment(format!(
+                "ERROR: assignment target at depth {} exceeds stack window (16)",
+                depth
+            )));
+            self.ops.push(TIROp::Pop(1));
+        }
+    }
+
+    /// Recover a dotted variable name from a place whose base is a variable.
+    fn place_dotted_name(place: &Spanned<Place>) -> Option<String> {
+        match &place.node {
+            Place::Var(name) => Some(name.clone()),
+            Place::FieldAccess(inner, field) => {
+                Self::place_dotted_name(inner).map(|b| format!("{}.{}", b, field.node))
+            }
+            Place::Index(..) => None,
+        }
+    }
+
+    /// Store into a dotted struct field `base.f0.f1…` (width-1 field only).
+    fn build_dotted_field_store(&mut self, name: &str, value: &Expr) {
+        let parts: Vec<&str> = name.split('.').collect();
+        // Find the longest prefix that names a live variable, and bring it onto
+        // the stack BEFORE evaluating the value (so a reload can't land on top
+        // of the value word).
+        let mut base_split = None;
+        for split in 1..parts.len() {
+            let var_name = parts[..split].join(".");
+            if self.stack.has_var(&var_name) {
+                self.stack.access_var(&var_name);
+                self.flush_stack_effects();
+                base_split = Some(split);
+                break;
+            }
+        }
+        self.build_expr(value);
+        let Some(split) = base_split else {
+            self.ops.push(TIROp::Comment(format!(
+                "ERROR: unresolved assignment target '{}'",
+                name
+            )));
+            self.ops.push(TIROp::Pop(1));
+            self.stack.pop();
+            return;
+        };
+        let var_name = parts[..split].join(".");
+        let fields = &parts[split..];
+        let base_info = self.stack.find_var_depth_and_width(&var_name);
+        self.flush_stack_effects();
+        let Some((base_depth, _)) = base_info else {
+            self.ops.push(TIROp::Comment(format!(
+                "ERROR: unresolved assignment target '{}'",
+                name
+            )));
+            self.ops.push(TIROp::Pop(1));
+            self.stack.pop();
+            return;
+        };
+        match self.resolve_nested_field_offset(&var_name, fields) {
+            Some((combined_offset, 1)) => {
+                let real_depth = base_depth + combined_offset;
+                self.store_top_into(real_depth);
+            }
+            Some((_, field_width)) => {
+                self.ops.push(TIROp::Comment(format!(
+                    "ERROR: assignment to multi-word field '{}' (width {}) not yet supported on the stack machine",
+                    name, field_width
+                )));
+                self.ops.push(TIROp::Pop(1));
+            }
+            None => {
+                self.ops.push(TIROp::Comment(format!(
+                    "ERROR: unresolved field path '{}'",
+                    name
+                )));
+                self.ops.push(TIROp::Pop(1));
+            }
+        }
+        self.stack.pop();
+    }
+
+    /// Store into `a[idx]` with a constant index into a named variable
+    /// (width-1 element only).
+    fn build_index_store(
+        &mut self,
+        inner: &Spanned<Place>,
+        index: &Spanned<Expr>,
+        value: &Expr,
+    ) {
+        let base_name = match &inner.node {
+            Place::Var(name) if !name.contains('.') => Some(name.clone()),
+            _ => None,
+        };
+        let const_idx = match &index.node {
+            Expr::Literal(Literal::Integer(i)) => Some(*i as u32),
+            _ => None,
+        };
+        let (Some(name), Some(idx)) = (base_name, const_idx) else {
+            self.build_expr(value);
+            self.ops.push(TIROp::Comment(
+                "ERROR: only constant-index assignment into a named array is supported on the stack machine".to_string(),
+            ));
+            self.ops.push(TIROp::Pop(1));
+            self.stack.pop();
+            return;
+        };
+        if self.stack.has_var(&name) {
+            self.stack.access_var(&name);
+            self.flush_stack_effects();
+        }
+        self.build_expr(value);
+        let info = self.stack.find_var_with_elem_width(&name);
+        self.flush_stack_effects();
+        let Some((var_depth, var_width, elem_width)) = info else {
+            self.ops.push(TIROp::Comment(format!(
+                "ERROR: unresolved array '{}'",
+                name
+            )));
+            self.ops.push(TIROp::Pop(1));
+            self.stack.pop();
+            return;
+        };
+        if elem_width != 1 {
+            self.ops.push(TIROp::Comment(format!(
+                "ERROR: assignment to multi-word array element '{}[{}]' (elem width {}) not yet supported",
+                name, idx, elem_width
+            )));
+            self.ops.push(TIROp::Pop(1));
+            self.stack.pop();
+            return;
+        }
+        if (idx + 1) * elem_width > var_width {
+            self.ops.push(TIROp::Comment(format!(
+                "ERROR: index {} out of bounds for '{}' (width {})",
+                idx, name, var_width
+            )));
+            self.ops.push(TIROp::Pop(1));
+            self.stack.pop();
+            return;
+        }
+        let base_offset = var_width - (idx + 1) * elem_width;
+        let real_depth = var_depth + base_offset;
+        self.store_top_into(real_depth);
+        self.stack.pop();
+    }
+
     /// Append Pop ops to clean up locals created in an if/else branch.
     /// `post_depth` is stack_depth() after the branch body, `pre_depth` before.
     /// `keep` is the number of words to preserve on top (e.g. a tail expression value).
@@ -130,16 +331,7 @@ impl TIRBuilder {
             }
 
             Stmt::Assign { place, value } => {
-                if let Place::Var(name) = &place.node {
-                    self.build_expr(&value.node);
-                    let depth = self.stack.access_var(name);
-                    self.flush_stack_effects();
-                    if depth <= 15 {
-                        self.ops.push(TIROp::Swap(depth));
-                        self.ops.push(TIROp::Pop(1));
-                    }
-                    self.stack.pop();
-                }
+                self.build_assign(&place.node, &value.node);
             }
 
             Stmt::If {

--- a/src/ir/tir/stack/mod.rs
+++ b/src/ir/tir/stack/mod.rs
@@ -240,6 +240,13 @@ impl StackManager {
 
     /// Find depth, width, and elem_width of a named variable.
     /// Like find_var_depth_and_width but also returns elem_width for arrays.
+    /// True if a variable of this name is currently live (on the operand
+    /// stack or spilled). Does not mutate or reload.
+    pub(crate) fn has_var(&self, name: &str) -> bool {
+        self.on_stack.iter().any(|e| e.name.as_deref() == Some(name))
+            || self.spilled.iter().any(|v| v.name.as_deref() == Some(name))
+    }
+
     pub(crate) fn find_var_with_elem_width(&mut self, name: &str) -> Option<(u32, u32, u32)> {
         let ts = self.tick();
         let mut depth: u32 = 0;

--- a/src/ir/tree/lower/nox.rs
+++ b/src/ir/tree/lower/nox.rs
@@ -2078,18 +2078,29 @@ pub fn f() -> Field {
     }
 
     #[test]
-    fn array_element_assignment_is_honest_error() {
-        // trident's parser collapses `a[i] = v` to an unsupported place
-        // (`_error_`); the nox lowering must reject it, not miscompile.
+    fn array_element_assignment() {
+        // `a[i] = v` now parses to Place::Index and lowers to a subject edit.
         let src = "program test
 pub fn f() -> Field {
     let mut a: [Field; 3] = [1, 2, 3]
     a[1] = 20
+    a[0] + a[1] + a[2]
+}";
+        assert_eq!(run_src(src, &[]), 24);
+    }
+
+    #[test]
+    fn dynamic_array_index_assignment_is_honest_error() {
+        // A runtime index has no compile-time axis; the lowering must reject it.
+        let src = "program test
+pub fn f(i: Field) -> Field {
+    let mut a: [Field; 3] = [1, 2, 3]
+    a[i] = 20
     a[0]
 }";
         let file = crate::parse_source_silent(src, "t.tri").unwrap();
         let err = NoxCompiler::new().compile_file(&file).unwrap_err();
-        assert!(err.contains("unsupported assignment target"), "{}", err);
+        assert!(err.contains("compile-time constant"), "{}", err);
     }
 
     #[test]

--- a/src/syntax/parser/expr.rs
+++ b/src/syntax/parser/expr.rs
@@ -289,7 +289,26 @@ impl Parser {
 
     pub(super) fn expr_to_place(&self, expr: &Spanned<Expr>) -> Spanned<Place> {
         match &expr.node {
+            // `x` and dotted field access `p.x` (the parser encodes field
+            // access as a dotted variable name) both become Place::Var; the
+            // dotted form is split downstream (typecheck + lowering).
             Expr::Var(name) => Spanned::new(Place::Var(name.clone()), expr.span),
+            // `a[i] = v` — array/element assignment.
+            Expr::Index { expr: inner, index } => {
+                let base = self.expr_to_place(inner);
+                Spanned::new(
+                    Place::Index(Box::new(base), index.clone()),
+                    expr.span,
+                )
+            }
+            // `p.x = v` when it arrives as a structured field access.
+            Expr::FieldAccess { expr: inner, field } => {
+                let base = self.expr_to_place(inner);
+                Spanned::new(
+                    Place::FieldAccess(Box::new(base), field.clone()),
+                    expr.span,
+                )
+            }
             _ => Spanned::new(Place::Var("_error_".to_string()), expr.span),
         }
     }

--- a/src/typecheck/block.rs
+++ b/src/typecheck/block.rs
@@ -162,14 +162,26 @@ impl TypeChecker {
         }
     }
 
-    pub(super) fn check_place(&self, place: &Place, _span: Span) -> (Ty, bool) {
+    pub(super) fn check_place(&mut self, place: &Place, _span: Span) -> (Ty, bool) {
         match place {
             Place::Var(name) => {
                 if let Some(info) = self.lookup_var(name) {
-                    (info.ty.clone(), info.mutable)
-                } else {
-                    (Ty::Field, false)
+                    return (info.ty.clone(), info.mutable);
                 }
+                // Dotted name = struct field assignment (`p.x`, `p.q.r`). The
+                // mutability comes from the base variable; the type is that of
+                // the addressed field.
+                if let Some(base) = name.split('.').next() {
+                    if name.contains('.') {
+                        if let Some(info) = self.lookup_var(base) {
+                            let is_mut = info.mutable;
+                            if let Some(ty) = self.resolve_nested_field_access(name, _span) {
+                                return (ty, is_mut);
+                            }
+                        }
+                    }
+                }
+                (Ty::Field, false)
             }
             Place::FieldAccess(inner, field) => {
                 let (inner_ty, is_mut) = self.check_place(&inner.node, inner.span);
@@ -183,8 +195,9 @@ impl TypeChecker {
                     (Ty::Field, false)
                 }
             }
-            Place::Index(inner, _) => {
+            Place::Index(inner, index) => {
                 let (inner_ty, is_mut) = self.check_place(&inner.node, inner.span);
+                self.check_expr(&index.node, index.span);
                 if let Ty::Array(elem_ty, _) = &inner_ty {
                     (*elem_ty.clone(), is_mut)
                 } else {

--- a/src/typecheck/expr.rs
+++ b/src/typecheck/expr.rs
@@ -443,7 +443,7 @@ impl TypeChecker {
     /// Resolve nested field access from a dotted name like "st.s00.lo".
     /// Tries every prefix that could be a variable, then walks the
     /// remaining dot-separated fields through struct types.
-    fn resolve_nested_field_access(&mut self, name: &str, span: Span) -> Option<Ty> {
+    pub(super) fn resolve_nested_field_access(&mut self, name: &str, span: Span) -> Option<Ty> {
         let parts: Vec<&str> = name.splitn(name.len(), '.').collect();
         // Try increasingly long prefixes as the base variable.
         // For "st.s00.lo", tries "st" first, then "st.s00".

--- a/tests/nox_surface.rs
+++ b/tests/nox_surface.rs
@@ -196,20 +196,22 @@ fn structs_and_fields() {
     let src = "program test
 struct Point { x: Field, y: Field }
 pub fn f() -> Field {
-    let p = Point { x: 10, y: 20 }
+    let mut p = Point { x: 10, y: 20 }
+    p.x = 5
     p.x + p.y
 }";
-    assert_eq!(run(src, &[]), 30);
+    assert_eq!(run(src, &[]), 25);
 }
 
 #[test]
 fn arrays_and_indexing() {
     let src = "program test
 pub fn f() -> Field {
-    let a: [Field; 4] = [10, 20, 30, 40]
+    let mut a: [Field; 4] = [1, 2, 3, 4]
+    a[2] = 30
     a[0] + a[2] + a[3]
 }";
-    assert_eq!(run(src, &[]), 80);
+    assert_eq!(run(src, &[]), 35);
 }
 
 #[test]


### PR DESCRIPTION
## What

`p.x = v` and `a[i] = v` were documented in `reference/language.md` but never worked end to end on any target: the parser dropped `a[i] = v` to `Place::Var("_error_")`, and the mutability checker treated dotted `p.x` as an unknown immutable variable. This wires both forms through parser → typecheck → codegen.

- **parser** (`expr_to_place`): `a[i]` → `Place::Index`; structured `.field` → `Place::FieldAccess`; dotted `p.x` stays a `Place::Var` (the representation the read path already uses).
- **typecheck** (`check_place`): resolve dotted `Place::Var` — mutability from the base variable, type from the addressed field; typecheck the `Place::Index` index expr. Mutability still enforced.
- **TIR/triton** (`build_assign`): lowers all three place forms; field/element stores mirror the read path (compute slot depth, swap/pop in place); base var is stacked before the value so a spill-reload can't clobber it. Multi-word field/element writes and runtime indices emit an explicit error instead of the previous silent `swap 0; pop 1` no-op.
- **nox** already handled all three place forms, so this makes struct-field/array-element assignment work end to end on nox.

## Verification

- Full suite green: **1010** lib + **13** nox_surface e2e + 9 audit + 13 integration; 1 pre-existing ignored; **zero warnings**.
- nox e2e (`tests/nox_surface.rs`): `p.x = 5` and `a[2] = 30` compile through the full pipeline and reduce on the real nox VM.
- triton build tests (`src/api/tests/features.rs`): both forms compile to TASM with a real store and no error marker; assigning a field of an immutable binding is still rejected.

## Honest gaps

- Triton stores are width-1 (Field/U32/Bool fields, scalar array elements) and constant-index only; multi-word field/element writes and runtime array indices emit an explicit compile error rather than miscompiling. nox handles arbitrary width via subject edit but also errors on dynamic index.
- `reference/language.md` already documented these forms — reality now matches the reference; no reference change needed.