### PR TITLE
feat: os.state.read lowers to the nox look pattern; bundle declares state deps (M6)

### DIFF
--- a/reference/os.md
+++ b/reference/os.md
@@ -160,6 +160,7 @@ The developer writes `state.read(key)` — the proof machinery is invisible.
 | Object | Sui, Aptos | `dynamic_field.borrow(context_object, key)` |
 | UTXO | Neptune, Nockchain, Nervos, Aleo, Aztec | `divine()` + `merkle_authenticate(key, root)` |
 | Process | Linux, macOS, WASI, Browser, Android | File / environment read |
+| Graph | Cyber (nox) | `look(dimension, key)` — nox pattern 17, a deterministic BBG polynomial read proven with a Brakedown opening. `state.read(key)` reads BBG dimension 0 at cell `key`; the runtime subject carries the BBG state root as its head (`[root [params…]]`), declared by the bundle's `reads_state` flag. Richer dimension access is `os.cyber.*` territory (future). |
 | Journal | Boundless, Succinct, OpenVM Network | Compile error — no persistent state |
 
 ### `os.token` — Token Operations (PLUMB)

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -573,6 +573,21 @@ pub fn compile_to_bundle(
         .unwrap_or("program")
         .to_string();
 
+    // Tree targets: ask the lowering (the source of truth) whether the
+    // program reads persistent state, so the bundle can declare it and the
+    // runner knows to cons the BBG root onto the subject.
+    let reads_state = if options.target_config.architecture == crate::target::Arch::Tree {
+        entry_file
+            .map(|pm| {
+                let mut compiler = NoxCompiler::new();
+                let _ = compiler.compile_file(&pm.file);
+                compiler.reads_state()
+            })
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
     Ok(ProgramBundle {
         name,
         version: "0.1.0".to_string(),
@@ -590,5 +605,6 @@ pub fn compile_to_bundle(
             estimated_proving_ns: program_cost.estimated_proving_ns,
         },
         source_hash,
+        reads_state,
     })
 }

--- a/src/api/tests/features.rs
+++ b/src/api/tests/features.rs
@@ -317,3 +317,15 @@ fn test_field_and_index_assignment_immutable_still_rejected() {
         "assigning a field of an immutable struct must be rejected"
     );
 }
+
+#[test]
+fn test_os_state_read_still_undefined_on_triton() {
+    // os.state.read is registered only for tree targets; the triton path
+    // must keep its existing "undefined function" diagnostic unchanged.
+    let source =
+        "program test\nfn main() {\n    let v: Field = os.state.read(1)\n    pub_write(v)\n}";
+    let result = compile(source, "test.tri");
+    assert!(result.is_err(), "os.state.read must not typecheck on triton");
+    let msg = format!("{:?}", result.err());
+    assert!(msg.contains("undefined function"), "{}", msg);
+}

--- a/src/cost/nox.rs
+++ b/src/cost/nox.rs
@@ -236,13 +236,12 @@ fn walk(formula: &Noun, counts: &mut [u64; 18]) -> Bill {
         },
         // Unary ops: inv [8 a], not [13 a], hash [15 a] — body IS the operand.
         8 | 13 | 15 => base.add(walk(body, counts)),
-        // call [16 [tag_f check_f]] — both are formulas.
-        16 => match pair(body) {
+        // call [16 [tag_f check_f]], look [17 [ns_f key_f]] — both children
+        // are formulas.
+        16 | 17 => match pair(body) {
             Some((a, b)) => base.add(walk(a, counts)).add(walk(b, counts)),
             None => base,
         },
-        // look [17 body].
-        17 => base.add(walk(body, counts)),
         _ => base,
     }
 }

--- a/src/ir/tree/lower/nox.rs
+++ b/src/ir/tree/lower/nox.rs
@@ -320,6 +320,9 @@ pub struct NoxCompiler {
     structs: BTreeMap<String, Vec<(String, ast::Type)>>,
     /// Names of functions currently being inlined (cycle guard).
     call_stack: Vec<String>,
+    /// Set when the program lowers an `os.state.read` — the bundle declares
+    /// this so the runner supplies the subject as `[bbg_root [params…]]`.
+    reads_state: bool,
     /// Running count of nodes emitted by inlining (exponential-blowup guard).
     inline_nodes: usize,
 }
@@ -333,7 +336,15 @@ impl NoxCompiler {
             structs: BTreeMap::new(),
             call_stack: Vec::new(),
             inline_nodes: 0,
+            reads_state: false,
         }
+    }
+
+    /// Whether the compiled program reads persistent state (nox look). The
+    /// runner must then cons the BBG state root onto the subject:
+    /// `[root_tree [param_last … [param0 0]]]`.
+    pub fn reads_state(&self) -> bool {
+        self.reads_state
     }
 
     /// Compile an AST file. Returns the Noun formula for the entry function.
@@ -392,6 +403,19 @@ impl NoxCompiler {
         for param in &func.params {
             self.scope.bind(&param.name.node);
             self.scope.note_type(&param.name.node, param.ty.node.clone());
+        }
+        // A program that reads state receives the BBG root as the subject
+        // head, above the parameters: `[root_tree [param_last … [param0 0]]]`.
+        // Each `os.state.read` site re-conses this root to the head so the
+        // look pattern finds its limbs at the fixed axes 4/10/22/23.
+        if func
+            .body
+            .as_ref()
+            .map(|b| block_uses_state(&b.node))
+            .unwrap_or(false)
+        {
+            self.scope.bind("$bbg_root");
+            self.reads_state = true;
         }
         self.check_depth()?;
 
@@ -1182,6 +1206,42 @@ impl NoxCompiler {
                             name
                         ))
                     }
+                    "os.state.read" => {
+                        if args.len() != 1 {
+                            return Err("os.state.read takes 1 argument (key)".to_string());
+                        }
+                        if !self.call_stack.is_empty() {
+                            return Err(
+                                "nox: os.state.read inside a called function is not yet \
+                                 supported — read state in the entry function"
+                                    .to_string(),
+                            );
+                        }
+                        let root_pos = self.scope.lookup("$bbg_root").ok_or_else(|| {
+                            "nox: os.state.read site without a bound state root \
+                             (compiler bug — entry pre-scan missed it)"
+                                .to_string()
+                        })?;
+                        let root_axis = stack_axis(root_pos);
+                        // The look object is [root_tree | subject]: the key
+                        // formula runs against it, so compile the key with one
+                        // extra anonymous head binding.
+                        self.scope.push_frame();
+                        self.scope.bind("$look");
+                        let key_f = self.compile_expr(&args[0].node);
+                        self.scope.pop_frame();
+                        let key_f = key_f?;
+                        // [17 [[1 0] key]] — BBG dimension 0 at `key`
+                        // (reference/os.md, Per-OS Lowering, Graph row).
+                        let look_f = Noun::cell(
+                            Noun::atom(17),
+                            Noun::cell(nox_quote(Noun::atom(0)), key_f),
+                        );
+                        Ok(nox_compose(
+                            nox_cons(nox_axis(root_axis), nox_axis(1)),
+                            nox_quote(look_f),
+                        ))
+                    }
                     "divine" | "std.io.divine" => {
                         if !args.is_empty() {
                             return Err("divine takes no arguments".to_string());
@@ -1269,6 +1329,76 @@ impl NoxCompiler {
 }
 
 // ─── structural helpers ──────────────────────────────────────────
+
+/// Does this block (transitively) contain an `os.state.read` call?
+fn block_uses_state(block: &Block) -> bool {
+    block.stmts.iter().any(|s| stmt_uses_state(&s.node))
+        || block
+            .tail_expr
+            .as_ref()
+            .map(|e| expr_uses_state(&e.node))
+            .unwrap_or(false)
+}
+
+fn stmt_uses_state(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Let { init, .. } => expr_uses_state(&init.node),
+        Stmt::Assign { value, .. } => expr_uses_state(&value.node),
+        Stmt::TupleAssign { value, .. } => expr_uses_state(&value.node),
+        Stmt::If {
+            cond,
+            then_block,
+            else_block,
+        } => {
+            expr_uses_state(&cond.node)
+                || block_uses_state(&then_block.node)
+                || else_block
+                    .as_ref()
+                    .map(|b| block_uses_state(&b.node))
+                    .unwrap_or(false)
+        }
+        Stmt::For {
+            start, end, body, ..
+        } => {
+            expr_uses_state(&start.node)
+                || expr_uses_state(&end.node)
+                || block_uses_state(&body.node)
+        }
+        Stmt::Expr(e) => expr_uses_state(&e.node),
+        Stmt::Return(e) => e.as_ref().map(|e| expr_uses_state(&e.node)).unwrap_or(false),
+        Stmt::Match { expr, arms } => {
+            expr_uses_state(&expr.node)
+                || arms.iter().any(|a| block_uses_state(&a.body.node))
+        }
+        Stmt::Reveal { fields, .. } | Stmt::Seal { fields, .. } => {
+            fields.iter().any(|(_, e)| expr_uses_state(&e.node))
+        }
+        Stmt::Asm { .. } => false,
+    }
+}
+
+fn expr_uses_state(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call { path, args, .. } => {
+            path.node.as_dotted() == "os.state.read"
+                || args.iter().any(|a| expr_uses_state(&a.node))
+        }
+        Expr::BinOp { lhs, rhs, .. } => {
+            expr_uses_state(&lhs.node) || expr_uses_state(&rhs.node)
+        }
+        Expr::FieldAccess { expr, .. } => expr_uses_state(&expr.node),
+        Expr::Index { expr, index } => {
+            expr_uses_state(&expr.node) || expr_uses_state(&index.node)
+        }
+        Expr::StructInit { fields, .. } => {
+            fields.iter().any(|(_, e)| expr_uses_state(&e.node))
+        }
+        Expr::ArrayInit(es) | Expr::Tuple(es) => {
+            es.iter().any(|e| expr_uses_state(&e.node))
+        }
+        Expr::Literal(_) | Expr::Var(_) => false,
+    }
+}
 
 /// Does this block (transitively) contain a `return` statement?
 fn block_has_return(block: &Block) -> bool {
@@ -2185,6 +2315,131 @@ pub fn f() -> Field {
         };
         let err = c.compile_expr(&expr).unwrap_err();
         assert!(err.contains("sponge") || err.contains("Merkle"), "{}", err);
+    }
+
+    // ── os.state.read → look (pattern 17) ────────────────────────
+
+    /// Answers BBG dimension-0 looks with `key * 10 + 7`, but only when the
+    /// commitment limb matches the root this provider was built with.
+    struct StateProvider {
+        l0: u64,
+    }
+
+    impl nox::LookProvider for StateProvider {
+        fn look(&self, c: Goldilocks, ns: Goldilocks, key: Goldilocks) -> Option<Goldilocks> {
+            if c == Goldilocks::new(self.l0) && ns == Goldilocks::new(0) {
+                Some(Goldilocks::new(key.as_u64() * 10 + 7))
+            } else {
+                None
+            }
+        }
+    }
+
+    impl<const N: usize> nox::CallProvider<N> for StateProvider {
+        fn provide(
+            &self,
+            _reduction: &mut Reduction<N>,
+            _tag: Goldilocks,
+            _object: nox::Order,
+        ) -> Option<nox::Order> {
+            None
+        }
+    }
+
+    /// Subject for a state-reading program: `[root_tree [p_last … [p0 0]]]`.
+    fn state_subject(root: [u64; 4], params: &[u64]) -> Noun {
+        let root_tree = Noun::cell(
+            Noun::atom(root[0]),
+            Noun::cell(
+                Noun::atom(root[1]),
+                Noun::cell(Noun::atom(root[2]), Noun::atom(root[3])),
+            ),
+        );
+        Noun::cell(root_tree, subject(params))
+    }
+
+    fn run_state(src: &str, root: [u64; 4], params: &[u64]) -> u64 {
+        let noun = lower(src);
+        let mut ar = Reduction::<4096>::new();
+        let s = load(&mut ar, &state_subject(root, params));
+        let f = load(&mut ar, &noun);
+        let provider = StateProvider { l0: root[0] };
+        match reduce(&mut ar, s, f, 1_000_000, &provider, &mut NoTrace) {
+            Outcome::Ok(r, _) => ar.atom_value(r).unwrap().as_u64(),
+            o => panic!("state reduction failed: {:?}", o),
+        }
+    }
+
+    #[test]
+    fn os_state_read_lowers_to_look() {
+        let src = "program test\npub fn f(k: Field) -> Field { os.state.read(k) }";
+        let noun = lower(src);
+        let text = format!("{}", noun);
+        assert!(
+            text.contains("[17 [[1 0]"),
+            "must contain a look with quoted namespace 0: {}",
+            text
+        );
+        // key 4 → 47 from the provider
+        assert_eq!(run_state(src, [11, 22, 33, 44], &[4]), 47);
+    }
+
+    #[test]
+    fn os_state_read_key_expression_and_lets() {
+        // The key is an expression and the read happens under let bindings —
+        // the root axis and the key axes must both survive the shifts.
+        let src = "program test
+pub fn f(k: Field) -> Field {
+    let a: Field = 100
+    let v: Field = os.state.read(k + 1)
+    v + a
+}";
+        // key = 4+1 = 5 → look gives 57 → +100 = 157
+        assert_eq!(run_state(src, [9, 8, 7, 6], &[4]), 157);
+    }
+
+    #[test]
+    fn os_state_read_marks_reads_state() {
+        let src = "program test\npub fn f(k: Field) -> Field { os.state.read(k) }";
+        let file = crate::parse_source_silent(src, "t.tri").unwrap();
+        let mut c = NoxCompiler::new();
+        c.compile_file(&file).unwrap();
+        assert!(c.reads_state());
+
+        let src2 = "program test\npub fn f(k: Field) -> Field { k + 1 }";
+        let file2 = crate::parse_source_silent(src2, "t.tri").unwrap();
+        let mut c2 = NoxCompiler::new();
+        c2.compile_file(&file2).unwrap();
+        assert!(!c2.reads_state());
+    }
+
+    #[test]
+    fn os_state_read_in_helper_is_honest_error() {
+        let src = "program test
+fn helper(k: Field) -> Field { os.state.read(k) }
+pub fn f(k: Field) -> Field { helper(k) }";
+        let file = crate::parse_source_silent(src, "t.tri").unwrap();
+        let err = NoxCompiler::new().compile_file(&file).unwrap_err();
+        assert!(err.contains("entry function"), "{}", err);
+    }
+
+    #[test]
+    fn look_against_wrong_root_is_unavailable() {
+        // Provider bound to a different root: the look must fail the
+        // reduction (Unavailable), never fabricate a value.
+        let src = "program test\npub fn f(k: Field) -> Field { os.state.read(k) }";
+        let noun = lower(src);
+        let mut ar = Reduction::<4096>::new();
+        let s = load(&mut ar, &state_subject([1, 2, 3, 4], &[4]));
+        let f = load(&mut ar, &noun);
+        let provider = StateProvider { l0: 999 };
+        match reduce(&mut ar, s, f, 1_000_000, &provider, &mut NoTrace) {
+            Outcome::Ok(r, _) => panic!(
+                "expected failure, got {:?}",
+                ar.atom_value(r).map(|g| g.as_u64())
+            ),
+            _ => {}
+        }
     }
 
     // Helper: wrap a value in a dummy span

--- a/src/runtime/artifact.rs
+++ b/src/runtime/artifact.rs
@@ -33,6 +33,11 @@ pub struct ProgramBundle {
     pub cost: BundleCost,
     /// Content hash of the source AST (hex).
     pub source_hash: String,
+    /// The program reads persistent state (nox: look pattern over BBG).
+    /// The runner must supply the state and cons its root onto the subject
+    /// (`[root_tree [params…]]`). Absent in JSON = false — old bundles and
+    /// old readers are unaffected.
+    pub reads_state: bool,
 }
 
 /// Function metadata within a bundle.
@@ -80,6 +85,10 @@ impl ProgramBundle {
             "  \"source_hash\": {},\n",
             json_string(&self.source_hash)
         ));
+        // Additive, backward-compatible: only emitted when true.
+        if self.reads_state {
+            out.push_str("  \"reads_state\": true,\n");
+        }
 
         // Cost
         out.push_str("  \"cost\": {\n");
@@ -133,6 +142,7 @@ impl ProgramBundle {
         let entry_point = extract_string(json, "entry_point")?;
         let source_hash = extract_string(json, "source_hash")?;
         let assembly = extract_string(json, "assembly")?;
+        let reads_state = extract_bool(json, "reads_state").unwrap_or(false);
         let padded_height = extract_u64(json, "padded_height").unwrap_or(0);
         let estimated_proving_ns = extract_u64(json, "estimated_proving_ns").unwrap_or(0);
 
@@ -151,6 +161,7 @@ impl ProgramBundle {
                 estimated_proving_ns,
             },
             source_hash,
+            reads_state,
         })
     }
 }
@@ -175,6 +186,20 @@ fn json_string(s: &str) -> String {
     }
     out.push('"');
     out
+}
+
+/// Extract a boolean value for a key from JSON (None if the key is absent).
+fn extract_bool(json: &str, key: &str) -> Option<bool> {
+    let pattern = format!("\"{}\"", key);
+    let start = json.find(&pattern)?;
+    let rest = json[start + pattern.len()..].trim_start_matches([':', ' ']);
+    if rest.starts_with("true") {
+        Some(true)
+    } else if rest.starts_with("false") {
+        Some(false)
+    } else {
+        None
+    }
 }
 
 /// Extract a string value for a key from JSON.
@@ -282,14 +307,30 @@ mod tests {
                 estimated_proving_ns: 1_000_000,
             },
             source_hash: "deadbeef".to_string(),
+            reads_state: false,
         }
+    }
+
+    #[test]
+    fn reads_state_roundtrips_when_true() {
+        let mut bundle = sample_bundle();
+        bundle.reads_state = true;
+        let json = bundle.to_json();
+        assert!(json.contains("\"reads_state\": true"));
+        let parsed = ProgramBundle::from_json(&json).expect("parse failed");
+        assert!(parsed.reads_state);
     }
 
     #[test]
     fn bundle_json_roundtrip() {
         let bundle = sample_bundle();
         let json = bundle.to_json();
+        assert!(
+            !json.contains("reads_state"),
+            "reads_state must be absent when false (backward-compatible JSON)"
+        );
         let parsed = ProgramBundle::from_json(&json).expect("parse failed");
+        assert!(!parsed.reads_state, "absent field must parse as false");
 
         assert_eq!(parsed.name, bundle.name);
         assert_eq!(parsed.version, bundle.version);

--- a/src/typecheck/builtins.rs
+++ b/src/typecheck/builtins.rs
@@ -59,6 +59,21 @@ impl TypeChecker {
             );
         }
 
+        // Portable OS state — currently lowered only on tree targets (nox:
+        // pattern 17 look over BBG). Other targets keep their existing
+        // "undefined function" diagnostic until their lowering lands, so
+        // registration is gated by architecture. See reference/os.md
+        // ("Per-OS Lowering", Graph row).
+        if self.target_config.architecture == crate::target::Arch::Tree {
+            b.insert(
+                "os.state.read".into(),
+                FnSig {
+                    params: vec![("key".into(), Ty::Field)],
+                    return_ty: Ty::Field,
+                },
+            );
+        }
+
         // Non-deterministic input
         b.insert(
             "divine".into(),

--- a/tests/nox_surface.rs
+++ b/tests/nox_surface.rs
@@ -224,6 +224,101 @@ pub fn f() -> Field {
     assert_eq!(run(src, &[]), 7);
 }
 
+// ── os.state.read → look (pattern 17) ────────────────────────────
+
+struct StateProvider {
+    l0: u64,
+}
+
+impl nox::LookProvider for StateProvider {
+    fn look(
+        &self,
+        c: Goldilocks,
+        ns: Goldilocks,
+        key: Goldilocks,
+    ) -> Option<Goldilocks> {
+        if c == Goldilocks::new(self.l0) && ns == Goldilocks::new(0) {
+            Some(Goldilocks::new(key.as_u64() * 10 + 7))
+        } else {
+            None
+        }
+    }
+}
+
+impl<const M: usize> nox::CallProvider<M> for StateProvider {
+    fn provide(
+        &self,
+        _r: &mut Reduction<M>,
+        _tag: Goldilocks,
+        _object: nox::Order,
+    ) -> Option<nox::Order> {
+        None
+    }
+}
+
+#[test]
+fn os_state_read_end_to_end() {
+    // Full pipeline: parse → typecheck (nox target) → lowering → printed
+    // noun → reduce with a LookProvider. Subject = [root_tree [k 0]] per the
+    // reads_state contract (reference/os.md, Graph row).
+    let src = "program test\npub fn f(k: Field) -> Field { os.state.read(k) + 1 }";
+    let formula_str = trident::compile_with_options(src, "surface.tri", &nox_options())
+        .expect("compile for nox failed");
+    assert!(formula_str.contains("[17 [[1 0]"), "look missing: {}", formula_str);
+    let formula = parse(&formula_str);
+
+    let root = [11u64, 22, 33, 44];
+    let root_tree = N::Cell(
+        Box::new(N::Atom(root[0])),
+        Box::new(N::Cell(
+            Box::new(N::Atom(root[1])),
+            Box::new(N::Cell(Box::new(N::Atom(root[2])), Box::new(N::Atom(root[3])))),
+        )),
+    );
+    let subj = N::Cell(Box::new(root_tree), Box::new(subject_noun(&[4])));
+
+    let mut ar = Reduction::<4096>::new();
+    let f = load(&mut ar, &formula);
+    let s = load(&mut ar, &subj);
+    let provider = StateProvider { l0: root[0] };
+    match reduce(&mut ar, s, f, 5_000_000, &provider, &mut NoTrace) {
+        // key 4 → 47, +1 = 48
+        Outcome::Ok(r, _) => assert_eq!(ar.atom_value(r).unwrap().as_u64(), 48),
+        o => panic!("reduction failed: {:?}", o),
+    }
+}
+
+#[test]
+fn os_state_read_sets_bundle_flag() {
+    // compile_to_bundle must declare the state dependency; a stateless
+    // program must not.
+    let dir = std::env::temp_dir().join("trident_os_state_bundle_test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let stateful = dir.join("stateful.tri");
+    std::fs::write(
+        &stateful,
+        "program stateful\npub fn f(k: Field) -> Field { os.state.read(k) }",
+    )
+    .unwrap();
+    let stateless = dir.join("stateless.tri");
+    std::fs::write(
+        &stateless,
+        "program stateless\npub fn f(k: Field) -> Field { k + 1 }",
+    )
+    .unwrap();
+
+    let b1 = trident::compile_to_bundle(&stateful, &nox_options()).expect("bundle failed");
+    assert!(b1.reads_state, "state-reading program must declare reads_state");
+    assert!(b1.to_json().contains("\"reads_state\": true"));
+
+    let b2 = trident::compile_to_bundle(&stateless, &nox_options()).expect("bundle failed");
+    assert!(!b2.reads_state);
+    assert!(
+        !b2.to_json().contains("reads_state"),
+        "stateless bundle JSON must omit the field (backward compat)"
+    );
+}
+
 // ── builtins ─────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes the trident-side M6 residual: "os.state.read lowers to look; bundle declares state deps".

## Design (reference resolved first)

`reference/os.md` Per-OS Lowering gains the **Graph** row: on Cyber (nox), `state.read(key)` is **pattern 17** — a deterministic BBG polynomial read proven with a Brakedown opening, reading **BBG dimension 0** at cell `key`. The runtime subject carries the state root as its head, `[root_tree [params…]]`, declared by the bundle. Richer dimension access is `os.cyber.*` (future).

## What

- **typecheck**: `os.state.read(key: Field) -> Field` registered **only for tree targets**. Triton keeps its exact pre-existing "undefined function" diagnostic (pinned by test) — zero regression.
- **NoxCompiler**: entry functions that read state bind a hidden `$bbg_root` above the params. Each read site re-conses the root to the subject head — `compose(cons([0 root_axis],[0 1]), quote([17 [[1 0] key]]))` — so look's fixed root axes (4/10/22/23) hold no matter how deep the site sits under lets/branches/loops; the key expression compiles against the extended subject. Formula shape matches joy's hand-built `[17 [[1 ns] [1 key]]]`.
- **Honest error**: `os.state.read` inside an inlined helper is rejected ("read state in the entry function") — callee subjects carry no root yet.
- **cost model sync**: look's body is a *pair* of formulas; the reduction walk now counts both children (was under-counting).
- **ProgramBundle** (`artifact.rs`, the boundary): additive `reads_state: bool`. JSON emitted only when true; absent parses as false — old bundles/readers byte-identical (roundtrip-pinned). `compile_to_bundle` derives the flag from `NoxCompiler::reads_state()` — the lowering is the source of truth, no syntactic guessing.

## Verification

- Reduce-backed unit tests: LookProvider answers keyed on (ns, key) with the commitment limb checked against the subject root; key-expression + let-shift case; **wrong-root look fails the reduction** (never fabricates); helper-fn error; flag derivation.
- e2e (`tests/nox_surface.rs`): full pipeline (parse → typecheck → lowering → printed noun) → reduce with LookProvider → `os.state.read(k) + 1` = 48 for key 4; bundle flag set for stateful, omitted for stateless.
- Full suite green: **1007 lib** (+7) + **15 nox_surface** (+2) + 9 audit + 13 integration; 1 pre-existing ignored; **zero warnings**.

## Joy side (left alone, as instructed)

Replacing joy's hand-built `.nox` look test with a trident-compiled program needs joy's `build_subject` to cons the live state root when `bundle.reads_state` — that's joy wiring, untouched here. Two joy follow-ups when it bumps trident: (1) add `reads_state` to its `ProgramBundle` literal (new struct field), (2) cons the root per the declared subject contract. Its hand-built test stays valid meanwhile.

## Honest gaps

- Dimension is fixed at 0; multi-dimension reads await `os.cyber.*`.
- State reads only in the entry function (inlined helpers error honestly).
- `os.state.write/exists/read_n/write_n` remain unlowered on nox (no write pattern exists in nox; look is read-only) — they keep the undefined-function diagnostic everywhere.