### PR TITLE
docs: README hero — nox default, joy prove/verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,11 +2035,11 @@ dependencies = [
 
 [[package]]
 name = "cyber-hemera"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "cyber-nox"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "cyber-hemera",
  "strata-nebu",
@@ -3991,14 +3991,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mir-format"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "moddef"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5791,25 +5783,25 @@ dependencies = [
 
 [[package]]
 name = "strata-compute"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "strata-core",
 ]
 
 [[package]]
 name = "strata-core"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "strata-ext"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "strata-core",
 ]
 
 [[package]]
 name = "strata-nebu"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "strata-compute",
  "strata-core",
@@ -5819,7 +5811,7 @@ dependencies = [
 
 [[package]]
 name = "strata-proof"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "strata-core",
 ]
@@ -6560,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "trident-lang"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ariadne",
  "blake3",
@@ -6571,7 +6563,6 @@ dependencies = [
  "cyber-hemera",
  "cyber-nox",
  "insta",
- "mir-format",
  "petgraph 0.7.1",
  "pollster",
  "rayon",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ Trident is a provable programming language.
 
 Every variable, every operation, every function compiles to arithmetic
 over the Goldilocks prime field (p = 2^64 - 2^32 + 1). Programs produce
-STARK proofs — hash-based, post-quantum secure, no trusted setup.
+cryptographic proofs of correct execution — hash-based, post-quantum
+secure, no trusted setup, no elliptic curves.
+
+The default target is **nox**, the proof-native VM of the
+[soft3](https://soft3.org) stack: `trident build` emits a `.nox`
+formula, and the [joy](https://github.com/cyberia-to/joy) warrior runs,
+proves and verifies it — a real [zheng](https://github.com/cyberia-to/zheng)
+proof, by default, out of the box. Triton VM remains fully supported via
+`--target triton` and the [trisha](https://github.com/cyberia-to/trisha)
+warrior — the original STARK path.
 
 ---
 
@@ -29,23 +38,22 @@ STARK proofs — hash-based, post-quantum secure, no trusted setup.
 ```trident
 program hello_proof
 
-fn main() {
-    let a: Field = secret_read()
-    let b: Field = secret_read()
-    pub_write(a + b)
+fn main(a: Field, b: Field) -> Field {
+    a + b
 }
 ```
 
 ```
-$ trident build hello.tri
-$ trident prove hello --secret 7 --secret 13
-  Proof generated (924 cycles, 11 KB)
-$ trident verify hello
-  Valid: output = 20, inputs hidden
+$ trident build hello.tri              # -> hello.nox (default target)
+$ joy prove hello.tri --input-values 7,13 --output hello.zheng.json
+  Proved in 4 ms: 5 reductions, 3 accumulator groups, 19608 bytes
+$ joy verify hello.tri --proof hello.zheng.json
+  Verification: PASS (zheng proof)
 ```
 
-A cryptographic proof that `a + b = 20` without revealing `a` or `b`.
-Quantum-safe. Zero-knowledge. No trusted setup. No elliptic curves.
+A cryptographic proof that `a + b = 20`, verified without re-running the
+program. Quantum-safe. No trusted setup. No elliptic curves. On Triton
+(`--target triton`), the same source proves with a STARK via `trisha`.
 
 ---
 


### PR DESCRIPTION
Aligns the README's hero example with the shipped default (nox target, joy warrior, real zheng proof) instead of the stale triton-only STARK framing.