### PR TITLE
chore: exclude media/ from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/cyberia-to/trident"
 readme = "README.md"
 keywords = ["zk", "provable", "compiler", "blockchain", "zero-knowledge"]
 categories = ["compilers", "cryptography"]
-exclude = ["docs/", "examples/", "tests/snapshots/"]
+exclude = ["docs/", "examples/", "tests/snapshots/", "media/"]
 
 [lib]
 name = "trident"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ alias: Tri, tri, the provable language
 > the way that they do. So you can see what's to come.
 
 <p align="center">
-  <img src="media/tri.gif" width="100%" alt="Trident" />
+  <img src="https://raw.githubusercontent.com/cyberia-to/trident/master/media/tri.gif" width="100%" alt="Trident" />
 </p>
 
 Trident is a provable programming language.


### PR DESCRIPTION
9.2MB gif was almost the entire package weight and the likely cause of cargo publish's HTTP/2 stream errors. Package drops from 13.5MB to 4.3MB (955KB compressed). README image now uses an absolute GitHub URL so crates.io's README render still works.