### PR TITLE
docs: 0.2.0 Cast release notes + doc sweep

### DIFF
--- a/.claude/plans/soft3-release.md
+++ b/.claude/plans/soft3-release.md
@@ -1,5 +1,11 @@
 # trident 0.2.0 — the soft3 release
 
+**STATUS: shipped 2026-09-08.** trident-lang 0.2.0 + cyber-joy 0.2.1 on
+crates.io, GitHub releases cut, the whole harness republished
+(strata-nebu 0.1.1, cyber-hemera 0.3.1, cyber-lens 0.1.3, cyber-nox
+0.2.0, zheng 0.2.0, bbg 0.2.0). M0–M7 done; residuals recorded in
+CHANGELOG. Kelvin: still 512K (see roadmap).
+
 **One sentence:** trident compiles to nox by default with soft3 as its
 infrastructure — strata algebra and hemera hashes in the compiler, and a new
 warrior **joy** (the cyber battlefield, built the way trisha is built) doing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,93 @@
 Kelvin versioning: versions count down toward 0K (frozen forever).
 Lower is colder. Colder is more stable.
 
-## 0.2.0 — Unreleased
+## 0.2.0 / 512K — Cast (2026-09-08)
+
+The soft3 release. trident compiles to **nox** by default and the whole
+soft3 stack stands behind it — strata algebra and hemera hashes inside
+the compiler, nox execution, zheng proofs, bbg state — through a new
+warrior, **joy**. `cargo install trident-lang cyber-joy` gives
+build → run → prove → verify with a zheng proof, out of the box:
+
+```
+$ trident build hello.tri                  # hello.nox
+$ trident prove hello.tri --secret 7,13    # Proved in 15 ms: 17 reductions, 74 KB
+$ trident verify hello.zheng.json          # Verification: PASS (zheng proof)
+```
+
+Kelvin: the project stays at 512K. The cyber stack and Noun layers
+cleared most of their 256K checklists (see `reference/roadmap.md`), but
+a layer cools only when its whole tier clears — Cast is a hot release
+that poured the language into the soft3 mold.
+
+### nox is the default target
+- every command's `--target` defaults to `nox`; `--target triton` keeps
+  TASM and the trisha warrior. `TerrainConfig::nox()` is a built-in
+  fallback (like `triton()`), so an installed binary works from any
+  directory. `vm/nox/target.toml`: level 4, cost model, tests, joy as
+  warrior with `prover = true`.
+
+### the full language surface lowers to nox (M1)
+- statements lower to composable subject transformers; mutable
+  assignment is a subject edit (fixes lost mutations inside `if`/loop
+  arms); bounded `for` unrolls static bounds and guards dynamic ends;
+  function calls inline (recursion rejected, node budget); tuples,
+  structs and fixed arrays are cons-trees; `hash`, `assert*`, field
+  builtins lower to patterns. `divine()` emitted a malformed call —
+  fixed. every mapping is verified by reducing on the real nox VM.
+- struct-field and array-element assignment now reach the front end on
+  **both** targets. the Triton path previously compiled `a[i] = v` to
+  a silent `swap 0; pop 1` no-op; it now emits a real store or an
+  honest error (multi-word writes, runtime indices).
+- `os.state.read(key)` lowers to the look pattern (BBG dimension 0);
+  `ProgramBundle.reads_state` is additive and JSON-backward-compatible.
+- unsupported on nox is an explicit compile error, never wrong code:
+  sponge/Merkle/RAM/IO builtins, xfield ops, dynamic array index,
+  `return` inside loops.
+
+### honest cost model (M2)
+- `trident build --costs` bills reductions from the emitted noun;
+  branch-dependent cost is a `min..=max` range, exact only for
+  straight-line code; `trident bench` grows a `Nox(r)` column (2 of 42
+  baselines are inside the nox surface — the rest are `-`). the static
+  bill equals the runtime bill on straight-line programs.
+
+### joy — the cyber warrior (M3, M4)
+- `joy run` / `joy prove` / `joy verify` on nox: zheng proofs
+  (SuperSpartan + Brakedown + HyperNova folding), verified without
+  re-execution; hash blocks and BBG `look` reads prove; artifacts are
+  self-contained `.zheng.json`. `trident run/prove/verify` delegate to
+  it. Measured (release): add proves in 4 ms / 20 KB, a hash in 71 ms /
+  189 KB, two `divine()` secrets in 15 ms / 74 KB. github.com/cyberia-to/joy
+
+### differential harness
+- `tests/differential.rs`: the stdlib modules inside the nox surface
+  (fibonacci, poseidon) execute on nox and must equal independent Rust
+  ground truth; a census pin fails whenever the surface grows without
+  coverage. Triton×nox agreement pends trisha's build repair (trisha#1).
+
+### fixed in the stack, surfaced by this release
+- zheng: four silent soundness holes — `pattern_quote` constrained a
+  stale register, the relaxed-fold loophole, the whole arithmetic family
+  on a stale register map (mul/eq/branch violations were silently
+  accepted), relaxed-proof pairing at m>1 — and the axis / hash-rate /
+  look bindings that were the release blocker. zheng 0.2.0.
+- nox: call rows carried the arena Order of the check result instead of
+  its value, so every `divine()` proof failed verification; the branch
+  selector r10 was clobbered on success; the arena-forking parallel
+  executor hijacked std builds. cyber-nox 0.2.0. Filed: arena hang at
+  N ≥ 8192 (nox#2), spec/code budget drift (nox#1).
+- bbg: cli broken on master; QueryProof/Commitment/Opening serde. bbg
+  0.2.0, cyber-lens 0.1.3. lens: porphyry/genies drift filed (lens#2).
+
+### removed
+- the Rs → Trident MIR importer (`src/import/`, `mir-format`) leaves the
+  published crate: `mir-format` is `publish = false` by design and
+  `cargo publish` rejects any reference to an unpublished dependency
+  (path, git and optional forms alike). it returns as a companion crate.
+- `trident::poseidon2` — see BREAKING below.
+- `media/` is excluded from the package (a 9 MB gif was 70% of the
+  crate); the README image is an absolute URL.
 
 ### BREAKING: content hashes are now cyber-hemera
 
@@ -28,7 +114,14 @@ infrastructure.
 
 The compiler's Goldilocks arithmetic is now `strata-nebu`'s (bit-exact
 migration — field arithmetic values are unchanged; only the
-implementation moved).
+implementation moved). `babybear.rs`/`mersenne31.rs` stay: they are
+foreign-target fields (risczero, sp1), not stack algebra.
+
+### Install
+
+```
+cargo install trident-lang cyber-joy
+```
 
 ## 0.1.0 / 512K — Smelt (2026-02-26)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,13 +103,16 @@ reference is wrong or incomplete, update the reference to match reality.
 Four namespaces: `vm.*` (intrinsics), `std.*` (libraries), `os.*`
 (portable runtime), `os.<os>.*` (OS-specific). Source: `src/` (Rust
 compiler), `vm/` `std/` `os/` (Trident code). Compiler self-hosts
-toward provable compilation on Triton VM.
+toward provable compilation on nox (default target) and Triton VM.
 
 Use `tokei src/` or `find src/ -name '*.rs'` to explore module structure.
 
 ## Companion Repos
 
-- **trisha** (`~/git/trisha`) — Triton VM warrior. Executes, proves,
+- **joy** (`~/cyber/joy`) — nox warrior, the cyber battlefield: executes,
+  proves (zheng), verifies programs on the default target. Published as
+  `cyber-joy` (binary `joy`). Depends on trident via `path = "../trident"`.
+- **trisha** (`~/cyber/trisha`) — Triton VM warrior. Executes, proves,
   verifies, deploys programs compiled by trident. Depends on trident
   via `path = "../trident"`. ~2k LOC Rust + WGSL.
 - trisha patches triton-vm at build time via `patches/apply.nu`
@@ -119,7 +122,8 @@ Use `tokei src/` or `find src/ -name '*.rs'` to explore module structure.
 - When referencing files across repos, use repo-qualified paths
   (e.g. `trident/src/cli/mod.rs` vs `trisha/src/cli.rs`).
 - After editing trident code, rebuild trisha too:
-  `cargo install --path . --force && cd ../trisha && cargo install --path . --force`
+  `cargo install --path . --force && cd ../joy && cargo install --path cli --force`
+  (and trisha when the Triton path is touched).
 
 ## Five-Layer Architecture
 
@@ -316,9 +320,10 @@ baseline, neural optimizer. All must agree on correctness.
 - Classic TASM — `trident build` output
 - Neural TASM — neural optimizer output
 
-Four metrics: correctness (`trisha run` vs reference), execution speed
-(cycle count), proving time (`trisha prove`), verification time
-(`trisha verify`). Block-level training uses inline stack verifier
+Four metrics: correctness (`joy run` on nox / `trisha run` on Triton vs
+reference — `tests/differential.rs` anchors nox against Rust ground
+truth), execution speed (reductions / cycles), proving time (`joy prove`
+/ `trisha prove`), verification time (`joy verify` / `trisha verify`). Block-level training uses inline stack verifier
 (`src/cost/stack_verifier.rs`) for fast feedback.
 
 ## Compaction Survival

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Execution trace
   |
   |  target VM proves
   v
-STARK proof + claim
+proof + claim (zheng on nox, STARK on Triton)
   |
   |  target VM verifies
   v
@@ -250,7 +250,7 @@ opaque. Ken Thompson showed in 1984 that a compiler can inject
 backdoors invisible in the source.
 
 Trident breaks the chain. The compiler self-hosts: Trident source
-compiles Trident source, and the execution produces a STARK proof that
+compiles Trident source, and the execution produces a proof that
 compilation was faithful. Not "we audited the binary." Not "we
 reproduced the build." A cryptographic proof, from the mathematics
 itself, that the output corresponds to the input.
@@ -280,13 +280,16 @@ model is training. When it beats the compiler, the number appears.
 ## Quick Start
 
 ```
-cargo build --release
-trident build main.tri           # compile to TASM
-trident check main.tri           # type-check only
-trident test main.tri            # run #[test] functions
-trident fmt main.tri             # format source
-trident audit main.tri           # formal verification
-trident bench main.tri           # instruction count + cost
+cargo install trident-lang cyber-joy       # the compiler + the nox warrior
+trident build main.tri                     # compile to .nox (--target triton for TASM)
+trident run main.tri --input-values 3,5    # execute on nox (via joy)
+trident prove main.tri                     # zheng proof -> main.zheng.json
+trident verify main.zheng.json             # verify, no re-execution
+trident check main.tri                     # type-check only
+trident test main.tri                      # run #[test] functions
+trident fmt main.tri                       # format source
+trident audit main.tri                     # formal verification
+trident bench main.tri                     # cost: reductions (nox), instructions (triton)
 ```
 
 ---
@@ -298,14 +301,14 @@ trident bench main.tri           # instruction count + cost
 3. **Compile-time everything.** Types, array sizes, and costs known statically.
 4. **Constraints are features.** No heap, no dynamic dispatch — safety guarantees.
 5. **Provable first.** Designed for ZK. These constraints make great conventional programs too.
-6. **Minimal dependencies.** 5 runtime crates: clap, ariadne, blake3, tower-lsp, tokio.
+6. **Minimal dependencies.** Nothing outside the soft3 stack: strata (algebra), hemera (hash), nox (target) — plus clap, ariadne, tower-lsp, tokio, blake3.
 
 ---
 
 ## Source Tree
 
 ```
-src/          Compiler in Rust            ~36K lines, 5 runtime dependencies
+src/          Compiler in Rust            ~36K lines, soft3-native (strata · hemera · nox)
 vm/           VM intrinsics in Trident    Compiler primitives (hash, I/O, field ops)
 std/          Standard library in Trident Crypto, math, neural networks, compiler
 os/           OS bindings in Trident      Per-OS config, programs, and extensions

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ application, from a four-line proof to a sovereign DAO.
 | [Compiling a Program](guides/compiling-a-program.md) | Build, check, cost analysis |
 | [Running a Program](guides/running-a-program.md) | Execute, test, debug |
 | [Deploying a Program](guides/deploying-a-program.md) | Neptune scripts, multi-target deployment |
-| [Generating Proofs](guides/generating-proofs.md) | Execution trace to STARK proof |
+| [Generating Proofs](guides/generating-proofs.md) | Execution trace to proof — zheng on nox (default), STARK on Triton |
 | [Verifying Proofs](guides/verifying-proofs.md) | Proof checking, on-chain verification |
 | [Optimization](guides/optimization.md) | Cost reduction strategies |
 | [Prompt Templates](guides/prompts.md) | AI-assisted development prompts |

--- a/docs/explanation/atlas.md
+++ b/docs/explanation/atlas.md
@@ -231,7 +231,7 @@ Y." Anyone can verify this claim without re-compiling, without trusting
 the publisher's toolchain, without trusting anything except mathematics.
 
 The endgame is provable compilation. The Trident compiler self-hosts on
-Triton VM. Every compilation produces a STARK proof. Every Atlas package
+the target VM. Every compilation produces a proof (zheng on nox, STARK on Triton). Every Atlas package
 comes with a mathematical guarantee that it was compiled correctly --
 source to assembly, each transformation proven, chained into a single
 certificate. Trust becomes optional because verification is cheap.

--- a/docs/explanation/for-offchain-devs.md
+++ b/docs/explanation/for-offchain-devs.md
@@ -249,7 +249,7 @@ see [How STARK Proofs Work](../explanation/stark-proofs.md).
 
 ## The Lifecycle: Build, Prove, Verify
 
-Every Trident program follows three phases: compile to target assembly (`trident build`), execute and generate a STARK proof (via the target VM), verify the proof (milliseconds, by anyone). The [Tutorial](../tutorials/tutorial.md) walks through each phase. The [Guides](../guides/compiling-a-program.md) cover each step in depth.
+Every Trident program follows three phases: compile to target assembly (`trident build`), execute and generate a proof via the target's warrior (zheng on nox by default, STARK on Triton), verify the proof (milliseconds, by anyone). The [Tutorial](../tutorials/tutorial.md) walks through each phase. The [Guides](../guides/compiling-a-program.md) cover each step in depth.
 
 ---
 

--- a/docs/explanation/for-onchain-devs.md
+++ b/docs/explanation/for-onchain-devs.md
@@ -711,10 +711,7 @@ All cryptographic security comes from hash functions (Tip5) and FRI commitments 
 ### 1. Install Trident
 
 ```nu
-git clone https://github.com/nicktriton/trident
-cd trident
-cargo build --release
-# Add target/release/trident to your PATH
+cargo install trident-lang cyber-joy   # compiler + nox warrior; Triton needs trisha
 ```
 
 ### 2. Create a Project and Read the Hello World

--- a/docs/explanation/privacy.md
+++ b/docs/explanation/privacy.md
@@ -80,7 +80,7 @@ Goldilocks field F_p.
 - **Private transfers.** Prove conservation (inputs = outputs + fee)
   without revealing amounts or owners. The STARK guarantees correctness;
   commitments guarantee privacy.
-- **Provable computation.** Every state transition produces a STARK proof.
+- **Provable computation.** Every state transition produces a proof (zheng on nox, STARK on Triton).
   Any node verifies any transition without re-executing it. A phone
   verifies what a datacenter computed.
 - **Selective disclosure.** Prove properties about state without revealing

--- a/docs/explanation/stdlib.md
+++ b/docs/explanation/stdlib.md
@@ -27,7 +27,7 @@ neural networks, polynomial commitment, and quantum gate application.
 
 The Goldilocks field F_p (p = 2^64 - 2^32 + 1) is the bedrock. Every
 computation reduces to operations over this field. Every function compiles
-to an arithmetic circuit. Every circuit produces a STARK proof.
+to an arithmetic circuit. Every circuit produces a proof — zheng on nox, STARK on Triton.
 
 Most standard libraries organize around data structures: lists, maps,
 strings, I/O. Trident's stdlib organizes around a mathematical insight.

--- a/docs/guides/compiling-a-program.md
+++ b/docs/guides/compiling-a-program.md
@@ -2,9 +2,28 @@
 
 This guide covers everything about the Trident compilation process: how source code becomes Triton Assembly, how to invoke the compiler, how to read errors, and how to analyze proving cost before you ever run a program. It is the second stage of the Trident lifecycle (Writing -> Compiling -> Running -> Deploying -> Generating Proofs -> Verifying Proofs).
 
+> **Two targets, two proof systems.** Since 0.2.0 the default target is
+> **nox** (the soft3 stack): `trident build` emits `.nox`, and the
+> **joy** warrior runs, proves and verifies it — a **zheng** proof
+> (SuperSpartan + Brakedown + HyperNova folding), verified without
+> re-execution. Triton VM and its STARK remain fully supported via
+> `--target triton` and the trisha warrior. On the default target the
+> whole chain is:
+>
+> ```
+> trident build hello.tri                 # hello.nox
+> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
+> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> ```
+>
+> `trident run/prove/verify` delegate to the warrior registered for the
+> target. The Triton-specific material below stays accurate for
+> `--target triton`; zheng's construction lives in the zheng repo
+> (`specs/superspartan.md`, `accumulator.md`, `decider.md`).
+
 ## 🔧 The Compilation Pipeline
 
-Trident compiles `.tri` source files directly to [TASM](https://triton-vm.org/spec/) (Triton Assembly) with no intermediate representation. The pipeline has six stages:
+Trident compiles `.tri` source files directly to a nox formula (default target) or to [TASM](https://triton-vm.org/spec/) (Triton Assembly, `--target triton`). The pipeline has six stages:
 
 ```trident
 source (.tri)
@@ -45,10 +64,10 @@ trident build main.tri
 Output:
 
 ```text
-Compiled -> main.tasm
+Compiled -> main.nox
 ```
 
-The default output file replaces the `.tri` extension with `.tasm`. To specify a different path:
+The default output file replaces the `.tri` extension with the target's extension (`.nox` by default, `.tasm` with `--target triton`). To specify a different path:
 
 ```nu
 trident build main.tri -o output/program.tasm
@@ -419,4 +438,4 @@ where it is identified by its [content-addressed hash](../explanation/content-ad
 
 ## 🚀 Next Step
 
-[Running a Program](running-a-program.md) -- execute your compiled TASM in Triton VM.
+[Running a Program](running-a-program.md) -- execute your compiled program (joy on nox, Triton VM on `--target triton`).

--- a/docs/guides/generating-proofs.md
+++ b/docs/guides/generating-proofs.md
@@ -6,6 +6,25 @@
 > program has been compiled and executed. The previous stage is Deploying; the
 > next stage is [Verifying Proofs](verifying-proofs.md).
 
+> **Two targets, two proof systems.** Since 0.2.0 the default target is
+> **nox** (the soft3 stack): `trident build` emits `.nox`, and the
+> **joy** warrior runs, proves and verifies it — a **zheng** proof
+> (SuperSpartan + Brakedown + HyperNova folding), verified without
+> re-execution. Triton VM and its STARK remain fully supported via
+> `--target triton` and the trisha warrior. On the default target the
+> whole chain is:
+>
+> ```
+> trident build hello.tri                 # hello.nox
+> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
+> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> ```
+>
+> `trident run/prove/verify` delegate to the warrior registered for the
+> target. The Triton-specific material below stays accurate for
+> `--target triton`; zheng's construction lives in the zheng repo
+> (`specs/superspartan.md`, `accumulator.md`, `decider.md`).
+
 A Trident program that compiles, runs, and produces the right output is only
 halfway done. The point of writing in Trident is not just to compute a result
 -- it is to *prove* the result is correct. This document explains the proof

--- a/docs/guides/running-a-program.md
+++ b/docs/guides/running-a-program.md
@@ -3,9 +3,28 @@
 This is the third stage of the Trident program lifecycle:
 Writing -> Compiling -> Running -> Deploying -> Generating Proofs -> Verifying Proofs.
 
-Trident is a compiler, not a runtime. After `trident build` produces a `.tasm` file, execution happens inside [Triton VM](https://triton-vm.org/) -- a STARK-based zero-knowledge virtual machine. Trident's job ends at code generation; the VM takes it from there.
+Trident is a compiler, not a runtime. After `trident build` produces a `.nox` formula (default) or a `.tasm` file (`--target triton`), execution happens inside the target VM — nox via the joy warrior, or [Triton VM](https://triton-vm.org/) via trisha. Trident's job ends at code generation; `trident run` hands the bundle to the warrior.
 
 This guide covers how compiled Trident programs execute, how to feed them input, and how to test and debug them using the tools available today.
+
+> **Two targets, two proof systems.** Since 0.2.0 the default target is
+> **nox** (the soft3 stack): `trident build` emits `.nox`, and the
+> **joy** warrior runs, proves and verifies it — a **zheng** proof
+> (SuperSpartan + Brakedown + HyperNova folding), verified without
+> re-execution. Triton VM and its STARK remain fully supported via
+> `--target triton` and the trisha warrior. On the default target the
+> whole chain is:
+>
+> ```
+> trident build hello.tri                 # hello.nox
+> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
+> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> ```
+>
+> `trident run/prove/verify` delegate to the warrior registered for the
+> target. The Triton-specific material below stays accurate for
+> `--target triton`; zheng's construction lives in the zheng repo
+> (`specs/superspartan.md`, `accumulator.md`, `decider.md`).
 
 ## ▶️ From TASM to Execution
 
@@ -16,7 +35,7 @@ trident build main.tri              # produces main.tasm
 trident build main.tri -o out.tasm  # custom output path
 ```
 
-The resulting `.tasm` file is a complete, self-contained program in Triton VM's instruction set. To actually run it, you load the TASM into Triton VM. Trident itself has no `run` subcommand and no built-in interpreter -- it is purely a source-to-assembly compiler.
+The resulting `.tasm` file is a complete, self-contained program in Triton VM's instruction set. To actually run it, you load the TASM into Triton VM. `trident run` itself contains no interpreter -- it delegates to the warrior for the target (joy for nox, trisha for Triton).
 
 ## 📡 The I/O Model
 

--- a/docs/guides/verifying-proofs.md
+++ b/docs/guides/verifying-proofs.md
@@ -6,6 +6,25 @@ Given a proof and the public inputs, anyone can verify that a computation was pe
 
 For how proofs are generated, see [Generating Proofs](generating-proofs.md). For the underlying proof system, see [How STARK Proofs Work](../explanation/stark-proofs.md).
 
+> **Two targets, two proof systems.** Since 0.2.0 the default target is
+> **nox** (the soft3 stack): `trident build` emits `.nox`, and the
+> **joy** warrior runs, proves and verifies it — a **zheng** proof
+> (SuperSpartan + Brakedown + HyperNova folding), verified without
+> re-execution. Triton VM and its STARK remain fully supported via
+> `--target triton` and the trisha warrior. On the default target the
+> whole chain is:
+>
+> ```
+> trident build hello.tri                 # hello.nox
+> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
+> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> ```
+>
+> `trident run/prove/verify` delegate to the warrior registered for the
+> target. The Triton-specific material below stays accurate for
+> `--target triton`; zheng's construction lives in the zheng repo
+> (`specs/superspartan.md`, `accumulator.md`, `decider.md`).
+
 ---
 
 ## ✅ 1. What Is Proof Verification?

--- a/reference/roadmap.md
+++ b/reference/roadmap.md
@@ -8,9 +8,11 @@ state, focus dynamics — all written in Trident, all provable.
 Kelvin versioning: versions count down toward 0K (frozen forever).
 Lower layers freeze first.
 
-512K released 2026-02-26. Hot, not production ready.
-Developer preview and request for comment.
-`cargo install trident-lang` · [GitHub](https://github.com/cyberia-to/trident/releases/tag/v0.1.0)
+512K released 2026-02-26 (0.1.0 Smelt). Hot, not production ready.
+0.2.0 Cast released 2026-09-08 — still 512K: the language poured into
+the soft3 mold (nox default target, joy warrior, zheng proofs), the
+cyber stack and Noun layers cleared most of their 256K items.
+`cargo install trident-lang cyber-joy` · [GitHub](https://github.com/cyberia-to/trident/releases/tag/v0.2.0)
 
 Three targets before 256k release:
 
@@ -24,13 +26,13 @@ Layer           Current   First Release
 ───────────────────────────────────────
 CORE            256K         64K
 vm spec          32K         16K
-language         64K         32K
+language         32K         32K      ← indexed assignment landed (0.2.0)
 TIR              64K         64K
-Noun            256K        128K      ← AST→Noun path (tree targets)
+Noun            128K        128K      ← 256K cleared in 0.2.0 (NounBuilder, subject, cost)
 compiler         32K         32K
 std.*           128K         64K
 os.*            128K         64K
-cyber stack     256K        128K      ← nebu, hemera, nox, zheng, bbg
+cyber stack     256K        128K      ← 3/4 of 256K + nox/zheng integration done (0.2.0); os/cyber types open
 tooling          64K         32K
 AI              256K        128K
 Privacy         256K        128K
@@ -51,13 +53,13 @@ Quantum         256K        128K
 - [ ] tooling     Integration tests and formal verification
 - [ ] tooling     Beautiful website
 - [ ] tooling     Complete benchmark coverage
-- [ ] cyber stack Hemera hash migration (replace blake3 + custom poseidon2)
-- [ ] cyber stack nebu field adoption (Goldilocks bridge)
-- [ ] cyber stack vm/nox/ target profile + registration
+- [x] cyber stack Hemera hash migration (replace blake3 + custom poseidon2) — 0.2.0
+- [x] cyber stack nebu field adoption (Goldilocks bridge) — 0.2.0
+- [x] cyber stack vm/nox/ target profile + registration — 0.2.0, default target
 - [ ] cyber stack os/cyber/ target profile + type definitions
-- [ ] Noun        NounBuilder: direct AST→Noun lowering (bypass TIR for tree targets)
-- [ ] Noun        SubjectManager: variable→axis mapping for tree subjects
-- [ ] Noun        Focus cost model (exact compile-time prediction)
+- [x] Noun        NounBuilder: direct AST→Noun lowering (bypass TIR for tree targets) — 0.2.0
+- [x] Noun        SubjectManager: variable→axis mapping for tree subjects — 0.2.0
+- [x] Noun        Focus cost model (exact compile-time prediction) — 0.2.0: exact for straight-line code, min..=max ranges where bounds are dynamic
 ```
 
 ## 128K — the machine assembles
@@ -66,8 +68,8 @@ Quantum         256K        128K
 CORE        Hemera + Merkle as CORE programs, BBG prototype
 TIR         Lowering works for stack, register, and tree targets
 Noun        AST→Noun optimized: subject sharing, dead axis elimination, parallel marking
-cyber stack nox executor integration (trident build → .nox → nox execute → trace)
-cyber stack zheng prover integration (trace → zheng prove → proof)
+cyber stack ✓ nox executor integration (trident build → .nox → nox execute → trace) — joy, 0.2.0
+cyber stack ✓ zheng prover integration (trace → zheng prove → proof) — joy, 0.2.0
 cyber stack os.cyber.* types operational (Particle, Neuron, Cyberlink)
 compiler    ✓ All 6 stages + pipeline rewritten in .tri (9,195 LOC)
               lexer (824) → parser (2,723) → typecheck (1,502) →
@@ -84,11 +86,11 @@ Quantum     Quantum circuit simulation backend
 
 ```
 CORE        Transaction circuit, STARK verifier as CORE program
-language    Indexed assignment (arr[i] = val, s.field = val)
+language    ✓ Indexed assignment (arr[i] = val, s.field = val) — 0.2.0, both targets
 TIR         ✓ TIR builder, optimizer, lowerer self-hosted in .tri
 Noun        ✓ NounBuilder self-hosted in .tri
-cyber stack Full pipeline: .tri → nox → zheng → bbg (compile, execute, prove, verify)
-cyber stack Warrior binary for cyber target (like trisha for Triton)
+cyber stack ✓ Full pipeline: .tri → nox → zheng → bbg (compile, execute, prove, verify) — 0.2.0
+cyber stack ✓ Warrior binary for cyber target (like trisha for Triton) — joy, 0.2.0
 compiler    ✓ All stages self-hosted — wire lower when core/warrior ready
 std.*       23 std.skill.* shipped
 os.*        3+ OS namespaces operational (incl. os.cyber.*)


### PR DESCRIPTION
Full CHANGELOG for 0.2.0, roadmap checkboxes + Kelvin table (Noun→128K, language→32K, cyber stack stays 256K), guides open with the nox/zheng default and keep Triton material under --target triton, README quick start = real install + chain, CLAUDE.md companion repos (joy) and correct trisha path.