### PR TITLE
docs: real proof sizes, .zheng artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ build → run → prove → verify with a zheng proof, out of the box:
 
 ```
 $ trident build hello.tri                  # hello.nox
-$ trident prove hello.tri --secret 7,13    # Proved in 15 ms: 17 reductions, 74 KB
-$ trident verify hello.zheng.json          # Verification: PASS (zheng proof)
+$ trident prove hello.tri --secret 7,13    # Proved in 14 ms: 17 reductions, 20 KB
+$ trident verify hello.zheng               # Verification: PASS (zheng proof)
 ```
 
 Kelvin: 512K → 500K. Still hot, but the change is fundamental — the
@@ -60,9 +60,13 @@ clears.
 - `joy run` / `joy prove` / `joy verify` on nox: zheng proofs
   (SuperSpartan + Brakedown + HyperNova folding), verified without
   re-execution; hash blocks and BBG `look` reads prove; artifacts are
-  self-contained `.zheng.json`. `trident run/prove/verify` delegate to
-  it. Measured (release): add proves in 4 ms / 20 KB, a hash in 71 ms /
-  189 KB, two `divine()` secrets in 15 ms / 74 KB. github.com/cyberia-to/joy
+  self-contained binary `.zheng` files (postcard) with the prover's
+  folded witness never on the wire. `trident run/prove/verify` delegate
+  to it. Measured (release): add proves in 4 ms / 5.4 KB, two `divine()`
+  secrets in 14 ms / 20 KB, a hash in 70 ms / 52 KB — ~1.7 KiB per
+  accumulator group, one group per CCS structure (zheng#8 tracks
+  collapsing groups toward the 2–5 KB program-level target).
+  github.com/cyberia-to/joy
 
 ### differential harness
 - `tests/differential.rs`: the stdlib modules inside the nox surface

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ fn main(a: Field, b: Field) -> Field {
 
 ```
 $ trident build hello.tri              # -> hello.nox (default target)
-$ joy prove hello.tri --input-values 7,13 --output hello.zheng.json
-  Proved in 4 ms: 5 reductions, 3 accumulator groups, 19608 bytes
-$ joy verify hello.tri --proof hello.zheng.json
+$ joy prove hello.tri --input-values 7,13
+  Proved in 4 ms: 5 reductions, 3 accumulator groups, 5351 bytes
+$ joy verify hello.zheng
   Verification: PASS (zheng proof)
 ```
 
@@ -283,8 +283,8 @@ model is training. When it beats the compiler, the number appears.
 cargo install trident-lang cyber-joy       # the compiler + the nox warrior
 trident build main.tri                     # compile to .nox (--target triton for TASM)
 trident run main.tri --input-values 3,5    # execute on nox (via joy)
-trident prove main.tri                     # zheng proof -> main.zheng.json
-trident verify main.zheng.json             # verify, no re-execution
+trident prove main.tri                     # zheng proof -> main.zheng
+trident verify main.zheng                  # verify, no re-execution
 trident check main.tri                     # type-check only
 trident test main.tri                      # run #[test] functions
 trident fmt main.tri                       # format source

--- a/docs/guides/compiling-a-program.md
+++ b/docs/guides/compiling-a-program.md
@@ -12,8 +12,8 @@ This guide covers everything about the Trident compilation process: how source c
 >
 > ```
 > trident build hello.tri                 # hello.nox
-> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
-> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> trident prove hello.tri --secret 7,13   # hello.zheng (via joy, ~14 ms, 20 KB)
+> trident verify hello.zheng              # Verification: PASS (zheng proof)
 > ```
 >
 > `trident run/prove/verify` delegate to the warrior registered for the

--- a/docs/guides/generating-proofs.md
+++ b/docs/guides/generating-proofs.md
@@ -16,8 +16,8 @@
 >
 > ```
 > trident build hello.tri                 # hello.nox
-> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
-> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> trident prove hello.tri --secret 7,13   # hello.zheng (via joy, ~14 ms, 20 KB)
+> trident verify hello.zheng              # Verification: PASS (zheng proof)
 > ```
 >
 > `trident run/prove/verify` delegate to the warrior registered for the

--- a/docs/guides/running-a-program.md
+++ b/docs/guides/running-a-program.md
@@ -17,8 +17,8 @@ This guide covers how compiled Trident programs execute, how to feed them input,
 >
 > ```
 > trident build hello.tri                 # hello.nox
-> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
-> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> trident prove hello.tri --secret 7,13   # hello.zheng (via joy, ~14 ms, 20 KB)
+> trident verify hello.zheng              # Verification: PASS (zheng proof)
 > ```
 >
 > `trident run/prove/verify` delegate to the warrior registered for the

--- a/docs/guides/verifying-proofs.md
+++ b/docs/guides/verifying-proofs.md
@@ -16,8 +16,8 @@ For how proofs are generated, see [Generating Proofs](generating-proofs.md). For
 >
 > ```
 > trident build hello.tri                 # hello.nox
-> trident prove hello.tri --secret 7,13   # hello.zheng.json (via joy, ~15 ms)
-> trident verify hello.zheng.json         # Verification: PASS (zheng proof)
+> trident prove hello.tri --secret 7,13   # hello.zheng (via joy, ~14 ms, 20 KB)
+> trident verify hello.zheng              # Verification: PASS (zheng proof)
 > ```
 >
 > `trident run/prove/verify` delegate to the warrior registered for the


### PR DESCRIPTION
Numbers re-measured after joy 0.2.2 (binary wire) + zheng 0.2.1 (witness off the wire): add 5.4 KB, two secrets 20 KB, a hash 52 KB — ~1.7 KiB per accumulator group. CHANGELOG, README hero, guide preambles.