### PR TITLE
docs: README rewritten around nox by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,21 @@ alias: Tri, tri, the provable language
 Trident is a provable programming language.
 
 Every variable, every operation, every function compiles to arithmetic
-over the Goldilocks prime field (p = 2^64 - 2^32 + 1). Programs produce
-cryptographic proofs of correct execution — hash-based, post-quantum
-secure, no trusted setup, no elliptic curves.
+over the Goldilocks prime field (p = 2^64 - 2^32 + 1). A program is a
+formula; running it and proving it ran correctly are the same act.
 
-The default target is **nox**, the proof-native VM of the
-[soft3](https://soft3.org) stack: `trident build` emits a `.nox`
-formula, and the [joy](https://github.com/cyberia-to/joy) warrior runs,
-proves and verifies it — a real [zheng](https://github.com/cyberia-to/zheng)
-proof, by default, out of the box. Triton VM remains fully supported via
-`--target triton` and the [trisha](https://github.com/cyberia-to/trisha)
-warrior — the original STARK path.
+Trident is the language of the [soft3](https://soft3.org) stack. It
+compiles to **nox**, the proof-native VM, and the **joy** warrior runs,
+proves and verifies what it emits — a **zheng** proof, hash-based,
+post-quantum, no trusted setup, no elliptic curves. One algebra
+([strata](https://github.com/cyberia-to/strata)), one hash
+([hemera](https://github.com/cyberia-to/hemera)), one field, from source
+to proof. Twenty other engines and twenty-five unions are declared
+behind `--target`; Triton VM with its STARK is the second tested one.
+
+```
+cargo install trident-lang cyber-joy
+```
 
 ---
 
@@ -38,22 +42,31 @@ warrior — the original STARK path.
 ```trident
 program hello_proof
 
-fn main(a: Field, b: Field) -> Field {
+fn main() -> Field {
+    let a: Field = divine()
+    let b: Field = divine()
     a + b
 }
 ```
 
 ```
-$ trident build hello.tri              # -> hello.nox (default target)
-$ joy prove hello.tri --input-values 7,13
-  Proved in 4 ms: 5 reductions, 3 accumulator groups, 5351 bytes
-$ joy verify hello.zheng
-  Verification: PASS (zheng proof)
+$ trident build hello_proof.tri
+Compiled -> hello_proof.nox
+$ trident prove hello_proof.tri --secret 7,13
+Proved in 15 ms: 17 reductions, 12 accumulator groups, 19978 bytes
+Output: [20]
+hello_proof.zheng
+$ trident verify hello_proof.zheng
+Verification: PASS (zheng proof)
+  program: hello_proof
+  output:  [20]
+  cycles:  17
 ```
 
-A cryptographic proof that `a + b = 20`, verified without re-running the
-program. Quantum-safe. No trusted setup. No elliptic curves. On Triton
-(`--target triton`), the same source proves with a STARK via `trisha`.
+A proof that `a + b = 20` without revealing `a` or `b`, checked
+without re-running the program. The prover's witness never leaves the
+prover — the artifact carries the statement, the proof and the formula,
+nothing else.
 
 ---
 
@@ -97,23 +110,60 @@ $ trident build hello.tri --costs
 Five reductions billed before running; `joy run` executes in exactly
 five. Branch-dependent programs get an honest `min..=max` range.
 
-You know the proving bill before you run.
+---
+
+## The Stack
+
+On the default target a Trident program never leaves the soft3 stack:
+
+| step | component | what it does |
+|------|-----------|--------------|
+| compile | **trident** | `.tri` → `.nox` formula over 18 reduction patterns; cost in reductions |
+| execute | [nox](https://github.com/cyberia-to/nox) via [joy](https://github.com/cyberia-to/joy) | reduces the formula; the trace is the witness |
+| prove | [zheng](https://github.com/cyberia-to/zheng) via joy | SuperSpartan + Brakedown + HyperNova folding; ~1.7 KiB per accumulator group |
+| verify | joy | checks the proof against the statement — no re-execution |
+| state | [bbg](https://github.com/cyberia-to/bbg) | `os.state.read` lowers to the look pattern; reads carry proofs, the public root is in the statement |
+| algebra · hash | [strata](https://github.com/cyberia-to/strata) · [hemera](https://github.com/cyberia-to/hemera) | Goldilocks arithmetic and Poseidon2 inside the compiler — no parallel implementations |
+
+Measured on a laptop, release build: `(a+b)*a` proves in 4 ms into a
+5.4 KB artifact; two `divine()` secrets in 14 ms / 20 KB; one `hash`
+builtin in 70 ms / 52 KB. Proof size grows with the number of CCS
+structures a trace touches (3, 12, 23 above); collapsing them toward a
+2–5 KB program-level proof is [zheng#8](https://github.com/cyberia-to/zheng/issues/8).
 
 ---
 
-## Neptune
+## One Source, 21 Targets
 
-[Neptune Cash](https://neptune.cash/) is where Trident programs run on Triton (`--target triton`).
-It is the only blockchain with recursive STARK proofs in production —
-a proof verifies another proof inside itself, so any chain of
-transactions collapses into a single cryptographic check. No other
-chain does this today.
+A Trident program is written once against field elements; the target is
+a config in `vm/`, not a rewrite. `trident build --target <engine>`
+picks one. Levels are what exists, not what is planned — see
+[reference/targets.md](reference/targets.md).
 
-Neptune is programmable, private, mineable, and quantum-safe. Trident
-is its native language, targeting [Triton VM](https://triton-vm.org/).
+| level | engines |
+|-------|---------|
+| **tested** — end to end, proofs land | **nox** (default · zheng via joy) · **triton** (Triton VM · STARK via trisha) · **miden** |
+| **costed** — scaffold backend + cost model, not yet tested | sp1 · openvm · cairo |
+| **lowering** — pipeline wired, emission still stubbed | arm64 · x86-64 · riscv · nock |
+| **declared + documented** — config and reference, no lowering | risczero · jolt · aztec · avm · evm · wasm · sbpf · movevm · polkavm · ckb · tvm |
 
-The following programs are proposed standards — specifications written
-in Trident, compiling to TASM today, under validation before deployment:
+Above the engines sit **25 unions** — the operating systems and chains
+a program deploys into, each binding one engine (`os/`): neptune
+(bound — runtime bindings in Trident, on triton); linux, macos,
+android, browser, wasi on the native and wasm engines; ethereum,
+arbitrum, solana, polkadot, ton, near, cosmwasm, icp, sui, aptos,
+starknet, aztec, aleo, miden, nervos, nockchain, succinct, boundless,
+openvm-network — declared and documented, awaiting bindings.
+
+### Neptune (`--target triton`)
+
+[Neptune Cash](https://neptune.cash/) is the only blockchain with
+recursive STARK proofs in production — a proof verifies another proof
+inside itself, so any chain of transactions collapses into a single
+cryptographic check. Trident targets its [Triton VM](https://triton-vm.org/)
+through the [trisha](https://github.com/cyberia-to/trisha) warrior, and
+these programs are proposed Neptune standards — written in Trident,
+compiling to TASM today, under validation before deployment:
 
 | Program | What it proposes |
 |---------|-----------------|
@@ -122,11 +172,6 @@ in Trident, compiling to TASM today, under validation before deployment:
 | [Lock scripts](os/neptune/locks/) | Multisig, timelock, symmetric spending authorization |
 | [Type scripts](os/neptune/types/) | Token conservation laws verified in every transaction |
 | [Programs](os/neptune/programs/) | Recursive verification, proof aggregation, relay |
-
-These compile and pass tests. They are not yet deployed. The
-interesting thing is not the tokens — it's that every transaction on
-Neptune already carries a recursive proof, and these programs extend
-what those proofs can express.
 
 See the [Gold Standard](docs/explanation/gold-standard.md) for the full
 PLUMB specification and the [Skill Library](docs/explanation/skill-library.md)
@@ -144,7 +189,12 @@ primitives — `Field`, `Digest`, `XField` — map directly to what the
 VM computes. Rust compiled to RISC-V wraps field operations in
 byte-level emulation.
 
-The gap is not marginal:
+**On nox every field operation is one reduction.** The program is a
+formula over 18 patterns; the cost report before you run equals the
+reduction count after; the execution trace *is* the proof witness — no
+arithmetization step, no trace-to-circuit translation.
+
+**On Triton the gap to byte-emulating zkVMs is not marginal:**
 
 | Operation | Trident on Triton VM | Rust on SP1 | Rust on RISC Zero |
 |-----------|:---:|:---:|:---:|
@@ -178,7 +228,7 @@ A single lookup table over Goldilocks simultaneously functions as:
 | Cryptographic S-box | Hash nonlinearity | Security |
 | Neural activation | Network expressiveness | Intelligence |
 | FHE bootstrap | Encrypted evaluation | Privacy |
-| STARK lookup | Proof authentication | Verifiability |
+| Proof lookup | Proof authentication | Verifiability |
 
 One table. One field. Four purposes. When all systems operate over the
 same prime field, four separate mechanisms collapse into one data
@@ -187,7 +237,7 @@ structure read four ways.
 [Trinity](docs/explanation/trinity-bench.md) demonstrates this: a single
 Trident program encrypts input with LWE, runs a neural layer, hashes
 with Tip5, performs FHE bootstrapping, and commits via a quantum
-circuit — all inside one STARK trace.
+circuit — all inside one proof trace.
 
 To our knowledge, no existing system composes FHE, neural inference,
 hashing, and quantum circuits in a single proof.
@@ -229,20 +279,23 @@ See [Formal Verification](docs/explanation/formal-verification.md).
 
 ## Content-Addressed Code
 
-Every function has a unique cryptographic identity derived from its
-normalized AST. Names are metadata. The hash is the truth.
+Every function has a unique cryptographic identity: the hemera hash of
+its normalized AST — the same hash that names particles in the
+cybergraph. Names are metadata. The hash is the truth.
 
 ```
 $ trident deploy transfer.tri
   Hash:     #a7f3b2c1d4e8
   Verified: (audit certificate attached)
-  Cost:     47 cycles
+  Cost:     47 reductions
   Published to registry
 ```
 
 Rename a function — the hash doesn't change. Publish independently
 from the other side of the planet — same code, same hash. Verification
-certificates travel with the identity, not the name.
+certificates travel with the identity, not the name. And because nox
+memoizes by the hash of (formula, object), a deployed function is
+computed once for everyone.
 See [Content-Addressed Code](docs/explanation/content-addressing.md).
 
 ---
@@ -277,6 +330,8 @@ std::compiler::pipeline        0      1      -   0.00x
 `Neural` — a [13M-parameter GNN+Transformer](reference/neural.md)
 learning to emit better assembly than the compiler. The dashes mean the
 model is training. When it beats the compiler, the number appears.
+`trident bench` also reports a `Nox(r)` column — reductions, for the
+modules inside the nox surface.
 
 `src/` is the Rust bootstrap — it shrinks.
 `std/compiler/` is the Trident replacement — it grows.
@@ -298,6 +353,9 @@ trident audit main.tri                     # formal verification
 trident bench main.tri                     # cost: reductions (nox), instructions (triton)
 ```
 
+The Triton path needs [trisha](https://github.com/cyberia-to/trisha)
+on `PATH` the same way the nox path needs `joy`.
+
 ---
 
 ## Design Principles
@@ -306,8 +364,8 @@ trident bench main.tri                     # cost: reductions (nox), instruction
 2. **Bounded execution.** Explicit loop bounds. No recursion. No halting problem.
 3. **Compile-time everything.** Types, array sizes, and costs known statically.
 4. **Constraints are features.** No heap, no dynamic dispatch — safety guarantees.
-5. **Provable first.** Designed for ZK. These constraints make great conventional programs too.
-6. **Minimal dependencies.** Nothing outside the soft3 stack: strata (algebra), hemera (hash), nox (target) — plus clap, ariadne, tower-lsp, tokio, blake3.
+5. **Provable first.** Designed for proofs. These constraints make great conventional programs too.
+6. **One stack.** Nothing outside soft3: strata (algebra), hemera (hash), nox (target) — plus clap, ariadne, tower-lsp, tokio, blake3. No parallel implementations of anything the stack already provides.
 
 ---
 
@@ -315,17 +373,22 @@ trident bench main.tri                     # cost: reductions (nox), instruction
 
 ```
 src/          Compiler in Rust            ~36K lines, soft3-native (strata · hemera · nox)
-vm/           VM intrinsics in Trident    Compiler primitives (hash, I/O, field ops)
+vm/           Engines + intrinsics        21 target.toml profiles; intrinsics in Trident
 std/          Standard library in Trident Crypto, math, neural networks, compiler
-os/           OS bindings in Trident      Per-OS config, programs, and extensions
+os/           Unions in Trident           25 per-OS configs, programs, and extensions
+tests/        nox_surface.rs, differential.rs — every lowering reduces on the real VM
 ```
 
 ```
-vm.*              Compiler intrinsics       hash, sponge, pub_read, assert
+vm.*              Compiler intrinsics       hash, sponge, divine, assert
 std.*             Standard library          sha256, bigint, ecdsa, poseidon2
 os.*              Portable runtime          os.signal, os.neuron, os.state, os.time
 os.<target>.*     Target-specific APIs      os.neptune.xfield, os.solana.pda
 ```
+
+The warriors live beside the compiler:
+[joy](https://github.com/cyberia-to/joy) (nox, the cyber battlefield) and
+[trisha](https://github.com/cyberia-to/trisha) (Triton VM, Neptune).
 
 ---
 
@@ -337,6 +400,13 @@ os.<target>.*     Target-specific APIs      os.neptune.xfield, os.solana.pda
 **In development:** `std.nn` (field-native neural networks) ·
 `std.private` (ZK + FHE + MPC) · `std.quantum` (gates, error
 correction)
+
+On nox today the surface is: literals, let, arithmetic, comparison,
+if/else, early return, mutable assignment, bounded `for`, function
+calls, structs/arrays/tuples, `hash`, the `assert` family, field ops,
+`divine()`, `os.state.read`. Sponge/Merkle/RAM/IO builtins, xfield
+ops and dynamic array indices are explicit compile errors on nox —
+never wrong code — and work on Triton.
 
 ---
 
@@ -366,7 +436,10 @@ Full index: [docs/README.md](docs/README.md)
 
 ## Status
 
-This is a language from the future, under construction in the present.
+0.2.0 / 500K — **Cast**. The language poured into the soft3 mold: nox
+by default, a real prover, one algebra, one hash. Hot, not production
+ready. Kelvin versioning counts down toward 0K; the
+[roadmap](reference/roadmap.md) says what cools next.
 
 Treat it as experimental unless you already understand the constraints
 you are adopting. The architecture is built to expand targets over time,


### PR DESCRIPTION
Structural rewrite, not sentence patches: nox/joy/zheng spine, exact CLI transcript, stack table, 21 targets + 25 unions, Neptune scoped to --target triton, real cost output, honest nox surface list, 500K Cast status.