### PR TITLE
feat: Digest limb indexing on nox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 Kelvin versioning: versions count down toward 0K (frozen forever).
 Lower is colder. Colder is more stable.
 
+## Unreleased
+
+- `Digest` limbs index on nox: `d[k]` for k < 4 lowers to the hash
+  pair's axes (reference/language.md already said `Digest` is
+  `[Field; D]`; the typechecker rejected it). Enables Merkle paths
+  chained through digests — depth 32 costs 1,906 reductions statically
+  (825 in the 33 hash patterns). Stack targets still reject digest
+  indexing (no limb store yet).
+
 ## 0.2.0 / 500K — Cast (2026-09-08)
 
 The soft3 release. trident compiles to **nox** by default and the whole

--- a/src/ir/tree/lower/nox.rs
+++ b/src/ir/tree/lower/nox.rs
@@ -874,6 +874,7 @@ impl NoxCompiler {
             }
             Expr::Index { expr, .. } => match self.expr_type(&expr.node)? {
                 ast::Type::Array(inner, _) => Some(*inner),
+                ast::Type::Digest => Some(ast::Type::Field),
                 _ => None,
             },
             Expr::Call { path, .. } => {
@@ -1290,6 +1291,18 @@ impl NoxCompiler {
                         .to_string()
                 })?;
                 let base_f = self.compile_expr(&base.node)?;
+                if let Some(ast::Type::Digest) = self.expr_type(&base.node) {
+                    // nox's hash result is a balanced pair [[h0 h1] [h2 h3]]
+                    // (nox/rs/patterns/hash.rs), not an element cons-list:
+                    // limb k lives at axis 4 + k.
+                    if k >= 4 {
+                        return Err(format!(
+                            "nox: digest has 4 limbs, index {} is out of range",
+                            k
+                        ));
+                    }
+                    return Ok(nox_compose(base_f, nox_quote(nox_axis(4 + k as u64))));
+                }
                 Ok(elem_access(base_f, k as u32))
             }
             Expr::StructInit { path, fields } => {

--- a/src/typecheck/expr.rs
+++ b/src/typecheck/expr.rs
@@ -260,6 +260,14 @@ impl TypeChecker {
                 let _idx_ty = self.check_expr(&index.node, index.span);
                 match &inner_ty {
                     Ty::Array(elem_ty, _) => *elem_ty.clone(),
+                    // reference/language.md: Digest is `[Field; D]`. Limb access
+                    // is lowered on tree targets (nox: D = 4, a balanced pair);
+                    // the stack path has no digest-limb store yet.
+                    Ty::Digest(_)
+                        if self.target_config.architecture == crate::target::Arch::Tree =>
+                    {
+                        Ty::Field
+                    }
                     _ => {
                         self.error(
                             format!("index access on non-array type {}", inner_ty.display()),

--- a/tests/nox_surface.rs
+++ b/tests/nox_surface.rs
@@ -346,3 +346,37 @@ pub fn f() -> Field {
 }";
     run_expect_error(src, &[]);
 }
+
+/// reference/language.md: `Digest` is `[Field; D]`; on nox D = 4 and the
+/// limbs live at axes 4..7 of the hash pair. Limb access must reduce.
+#[test]
+fn digest_limbs_index_on_nox() {
+    let limbs: Vec<u64> = (0..4)
+        .map(|k| {
+            run(
+                &format!(
+                    "program limb\nfn main(a: Field) -> Field {{\n    let d: Digest = hash(a, 0, 0, 0, 0, 0, 0, 0)\n    d[{k}]\n}}\n"
+                ),
+                &[42],
+            )
+        })
+        .collect();
+    assert!(limbs.iter().all(|&l| l != 0), "limbs {limbs:?}");
+    assert_eq!(limbs.iter().collect::<std::collections::BTreeSet<_>>().len(), 4, "limbs distinct {limbs:?}");
+    // the same hash, summed limbs in-program == summed limbs out of program
+    let sum = run(
+        "program sum\nfn main(a: Field) -> Field {\n    let d: Digest = hash(a, 0, 0, 0, 0, 0, 0, 0)\n    d[0] + d[1] + d[2] + d[3]\n}\n",
+        &[42],
+    );
+    let p: u128 = 0xFFFF_FFFF_0000_0001;
+    assert_eq!(sum as u128, limbs.iter().map(|&l| l as u128).sum::<u128>() % p);
+}
+
+/// A depth-32 Merkle path chained through digest limbs — the operation the
+/// README compares across VMs — compiles and reduces on nox.
+#[test]
+fn merkle_path_depth_32_reduces_on_nox() {
+    let src = "program merkle32\n\nfn main(leaf: Field, s0: Field) -> Field {\n    let mut acc: Digest = hash(leaf, 0, 0, 0, 0, 0, 0, 0)\n    for i in 0..32 bounded 32 {\n        acc = hash(acc[0], acc[1], acc[2], acc[3], s0, 0, 0, 0)\n    }\n    acc[0]\n}\n";
+    let root = run(src, &[7, 9]);
+    assert_ne!(root, 0);
+}


### PR DESCRIPTION
Digest is [Field; D] per the language reference; d[k] now typechecks on tree targets and lowers to the hash pair's axes on nox (limb k at axis 4+k). Enables Merkle paths through digests: a depth-32 path is 1,906 reductions statically (825 in hashes). Stack path still rejects (honest error). +2 surface tests, full suite green.