### PR TITLE
landing: emitter scope

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -447,10 +447,15 @@
                     hand-emit for any machine. <code>trident compile -t
                     &lt;backend&gt;</code> turns the very formula joy proves into
                     native code for <b>28 backends</b>: every one below emitted
-                    real output for <code>hello.nox</code> today. these are
-                    emitters — execution and proving on this hardware are not
-                    wired yet; the point is that one program already speaks to
-                    all of it.
+                    real output for <code>hello.nox</code> today. honest scope:
+                    the emitters cover the atom-level patterns (axis, quote,
+                    branch, field arithmetic, bitwise) — programs using
+                    <code>hash</code>, <code>divine</code>, structs or state
+                    reads are refused with <code>UnsupportedPattern</code> —
+                    and they emit code, not traces: execution and proving on
+                    this hardware are not wired. the point is that one program
+                    already speaks to all of it; making it run and prove there
+                    is the next tier.
                 </p>
                 <div class="silicon">
                     <div class="chip"><b>CPU</b><p><code>x86-64</code> <code>arm64</code> <i>(JIT)</i> <code>rv64</code> <code>rv32</code> <i>(ESP32)</i> <code>rvv</code> <i>(RISC-V vector)</i> <code>thumb2</code> <i>(Cortex-M · STM32 · RP2040)</i> <code>hexagon</code> <i>(Qualcomm DSP)</i></p></div>


### PR DESCRIPTION
Same honesty fix as README PR #28, on the landing.