### PR TITLE
feat: neural optimizer behind a default-on feature; fix benches BeamConfig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,24 @@ exclude = ["docs/", "examples/", "tests/snapshots/", "media/"]
 name = "trident"
 path = "src/lib.rs"
 
+[features]
+# The neural optimizer (burn + the wgpu backend under it) is the heaviest
+# thing trident links. Default-on for the compiler binary; warriors that
+# embed trident as a library take `default-features = false` and skip the
+# whole burn/cubecl graph — which also keeps serde's feature set unified
+# with the vendored triton crates (trisha#1).
+default = ["neural"]
+neural = ["dep:burn", "dep:rayon", "dep:rkyv"]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 ariadne = "0.4"
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["io-std", "rt-multi-thread", "macros"] }
-burn = { version = "0.20", features = ["wgpu", "autodiff", "ndarray"] }
-rayon = "1.10"
+burn = { version = "0.20", features = ["wgpu", "autodiff", "ndarray"], optional = true }
+rayon = { version = "1.10", optional = true }
 serde = { version = "1", features = ["derive"] }
-rkyv = { version = "0.8", features = ["bytecheck"] }
+rkyv = { version = "0.8", features = ["bytecheck"], optional = true }
 serde_json = "1"
 nox = { package = "cyber-nox", version = "0.2", path = "../nox/rs" }
 nebu = { package = "strata-nebu", version = "0.1", path = "../strata/nebu/rs" }
@@ -54,6 +63,7 @@ path = "src/bin/trident-lsp.rs"
 [[bench]]
 name = "end_to_end"
 harness = false
+required-features = ["neural"]
 
 [[example]]
 name = "ref_std_crypto_poseidon2"

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -115,6 +115,7 @@ fn bench_beam_search(c: &mut Criterion) {
     let beam_config = BeamConfig {
         k: 8, // Reduced K for benchmark speed
         max_steps: 16,
+        ..Default::default()
     };
 
     c.bench_function("beam_search_k8_steps16", |b| {
@@ -189,6 +190,7 @@ fn bench_end_to_end(c: &mut Criterion) {
     let beam_config = BeamConfig {
         k: 8,
         max_steps: 16,
+        ..Default::default()
     };
 
     c.bench_function("end_to_end_20ops_k8", |b| {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -54,9 +54,11 @@ pub struct BuildArgs {
     #[arg(long, default_value = "debug")]
     pub profile: String,
     /// Run neural optimizer analysis (shows per-block decisions)
+    #[cfg(feature = "neural")]
     #[arg(long)]
     pub neural: bool,
     /// Train the neural optimizer for N epochs (implies --neural)
+    #[cfg(feature = "neural")]
     #[arg(long, value_name = "EPOCHS")]
     pub train: Option<u64>,
 }
@@ -77,7 +79,9 @@ pub fn cmd_build(args: BuildArgs) {
         network,
         union_flag,
         profile,
+        #[cfg(feature = "neural")]
         neural,
+        #[cfg(feature = "neural")]
         train,
     } = args;
     let bf = super::resolve_battlefield_compile(&target, &engine, &terrain, &network, &union_flag);
@@ -118,8 +122,8 @@ pub fn cmd_build(args: BuildArgs) {
     eprintln!("Compiled -> {}", out_path.display());
 
     // Neural optimizer analysis
-    let use_neural = neural || train.is_some();
-    if use_neural {
+    #[cfg(feature = "neural")]
+    if neural || train.is_some() {
         run_neural_analysis(&ri.entry, &options, train);
     }
 
@@ -196,6 +200,7 @@ pub fn cmd_build(args: BuildArgs) {
     }
 }
 
+#[cfg(feature = "neural")]
 fn run_neural_analysis(
     entry: &std::path::Path,
     options: &trident::CompileOptions,
@@ -397,6 +402,7 @@ fn run_neural_analysis(
 
 /// Build TIR from a source entry point (for neural analysis).
 /// Uses full project resolution so imports (use vm.*, std.*) work.
+#[cfg(feature = "neural")]
 fn build_tir(
     entry: &std::path::Path,
     options: &trident::CompileOptions,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@
 // crystal-domain: comp
 // ---
 pub mod audit;
+#[cfg(feature = "neural")]
 pub mod bench;
 pub mod build;
 pub mod mir;
@@ -22,6 +23,7 @@ pub mod registry;
 pub mod run;
 pub mod store;
 pub mod test;
+#[cfg(feature = "neural")]
 pub mod train;
 pub mod tree_sitter;
 pub mod trisha;

--- a/src/cli/trisha.rs
+++ b/src/cli/trisha.rs
@@ -252,6 +252,8 @@ pub fn trisha_args_with_inputs(base_args: &[&str], harness: &Harness) -> Vec<Str
 /// - `halt`, `call`, `return` preserved as-is
 ///
 /// The linked program is self-contained — all cross-module calls are resolved.
+// Used by `trident bench` (neural feature); the warrior harness itself stays ungated.
+#[cfg(feature = "neural")]
 pub fn generate_program_harness(
     tasm: &str,
     input_values: &[u64],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod field;
 pub mod import;
 pub mod ir;
 pub mod lsp;
+#[cfg(feature = "neural")]
 pub mod neural;
 pub mod package;
 pub mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod cli;
 use clap::{Parser, Subcommand};
 
 use cli::audit::{AuditArgs, EquivArgs};
+#[cfg(feature = "neural")]
 use cli::bench::BenchArgs;
 use cli::build::BuildArgs;
 use cli::mir::MirArgs;
@@ -27,6 +28,7 @@ use cli::registry::RegistryAction;
 use cli::run::RunArgs;
 use cli::store::StoreAction;
 use cli::test::TestArgs;
+#[cfg(feature = "neural")]
 use cli::train::TrainArgs;
 use cli::tree_sitter::TreeSitterArgs;
 use cli::verify::VerifyProofArgs;
@@ -62,8 +64,10 @@ enum Command {
     /// Show content hashes of functions (BLAKE3)
     Hash(HashArgs),
     /// Run benchmarks: compare Trident output vs hand-written TASM
+    #[cfg(feature = "neural")]
     Bench(BenchArgs),
     /// Train the neural optimizer on .tri files
+    #[cfg(feature = "neural")]
     Train(TrainArgs),
     /// Generate code scaffold from spec annotations
     Generate(GenerateArgs),
@@ -116,7 +120,9 @@ fn main() {
         Command::Doc(args) => cli::doc::cmd_doc(args),
         Command::Audit(args) => cli::audit::cmd_audit(args),
         Command::Hash(args) => cli::hash::cmd_hash(args),
+        #[cfg(feature = "neural")]
         Command::Bench(args) => cli::bench::cmd_bench(args),
+        #[cfg(feature = "neural")]
         Command::Train(args) => cli::train::cmd_train(args),
         Command::Generate(args) => cli::generate::cmd_generate(args),
         Command::View(args) => cli::view::cmd_view(args),


### PR DESCRIPTION
burn (and the cubecl/wgpu graph under it) is the heaviest thing trident
links. `default = ["neural"]` keeps the compiler binary unchanged, while
`--no-default-features` gives a light library build for warriors that
embed trident and never train: trisha now takes that path.

This is not only about build weight. cubecl-ir enables serde's `rc`
feature, which split serde into two instances in trisha's graph and made
the SAME twenty-first type fail to match itself (trisha#1). Dropping burn
from a warrior's graph removes that class of breakage at the source.

Gated: `neural` module, `trident bench`, `trident train`, build.rs's
--neural/--train, cli/trisha.rs's bench harness, and the end_to_end bench
target (required-features).

Also fixes a pre-existing break on master: benches/end_to_end.rs
constructed BeamConfig without min_tokens/length_alpha/rep_penalty/
rep_window; now `..Default::default()` (BeamConfig has a Default impl, so
no invented numbers).

Verified: default and --no-default-features both compile --all-targets
with zero warnings; 955+9+13+3+17+34 tests pass; trident bench --skip-neural
runs (42 modules, Tri/Hand 1.33x).
