### PR TITLE
docs+feat: the warrior API is a documented, executable contract (S2)

### DIFF
--- a/reference/README.md
+++ b/reference/README.md
@@ -44,6 +44,7 @@ and code disagree, the reference wins.
 | [Grammar](grammar.md) | Complete formal grammar (EBNF) |
 | [Intermediate Representation](ir.md) | TIR operations (54 ops, 4 tiers), lowering paths |
 | [Target Reference](targets.md) | OS model, target profiles, cost models |
+| [Warrior API](warrior-api.md) | What a warrior may link: the library contract, features, stability |
 
 ## Token Standards
 

--- a/reference/targets.md
+++ b/reference/targets.md
@@ -395,6 +395,11 @@ Three CLI commands delegate to warriors:
 All other commands (`build`, `check`, `audit`, `fmt`, `bench`, etc.)
 run locally in Trident with zero warrior involvement.
 
+A warrior also links `trident-lang` as a library — for the bundle type,
+the terrain config and (when it owns its lowering) TIR. That surface,
+its feature contract and its stability promise are in
+[warrior-api.md](warrior-api.md).
+
 ### Warrior vs Trident Responsibilities
 
 | Trident provides | Warriors provide |

--- a/reference/warrior-api.md
+++ b/reference/warrior-api.md
@@ -1,0 +1,127 @@
+# Warrior API
+
+A warrior is an external binary that owns execution, proving, verification
+and deployment on one battlefield. Trident compiles; warriors fight.
+
+Two contracts hold between them:
+
+| contract | direction | where |
+|---|---|---|
+| process | `trident run/prove/verify` → `<warrior>` on PATH | [targets.md](targets.md) §Warriors |
+| library | warrior links `trident-lang` as a Rust crate | this document |
+
+This document is the library contract: what a warrior may depend on,
+what the core promises not to break, and where the line between them
+runs.
+
+## The line
+
+A thing belongs to the **core** if it produces trident's own
+representation or every warrior consumes it: the front end (lexer,
+parser, AST), the type checker, TIR and its optimizer, nox lowering
+(nox is the semantics every other target is checked against), the cost
+framework, `audit`, the LSP, the package system, and the MIR import.
+
+A thing belongs to a **warrior** if it knows one machine: the lowering
+from TIR to that ISA, its cost model and verifier, its runtime, its
+prover, its deployment path, and its hand-written baselines.
+
+## Surface
+
+Everything below is `pub` in `trident-lang` and covered by the stability
+promise. Paths are as a warrior writes them.
+
+### Compilation
+
+```rust
+trident::compile_to_bundle(entry: &Path, options: &CompileOptions)
+    -> Result<ProgramBundle, Vec<Diagnostic>>
+```
+
+The primary entry point: a multi-module project in, a `ProgramBundle`
+out — assembly text, entry point, per-function hashes, cost, source
+hash, `reads_state`. A warrior that takes finished assembly needs
+nothing else.
+
+```rust
+trident::build_tir(source: &str, filename: &str, options: &CompileOptions)
+    -> Result<Vec<TIROp>, Vec<Diagnostic>>
+trident::build_tir_project(entry: &Path, options: &CompileOptions)
+    -> Result<Vec<TIROp>, Vec<Diagnostic>>
+```
+
+For a warrior that owns its own lowering: typed, optimized TIR — a flat
+op list, already monomorphized, with control flow structured. The
+warrior turns it into its ISA. `build_tir_project` resolves imports;
+`build_tir` is the single-file form.
+
+`CompileOptions` carries the `TerrainConfig` and the cfg flags. Build it
+with `trident::CompileOptions::default()` and set `target_config`, or
+take it from `trident::target` (`TerrainConfig::nox()`,
+`TerrainConfig::triton()`, or a `vm/<engine>/target.toml` load).
+
+### Runtime
+
+```rust
+trident::runtime::{ProgramBundle, ProgramInput, ExecutionResult, ProofData}
+trident::runtime::{Runner, Prover, Verifier, Guesser, Deployer}
+```
+
+`ProgramBundle` is the pipeline boundary. The five traits are the shapes
+a warrior implements; nothing in the core calls them — the CLI delegates
+by process, not by trait object. Implement the ones your battlefield
+supports.
+
+### Utilities
+
+```rust
+trident::hash::content_hash_bytes(data: &[u8]) -> [u8; 32]   // cyber-hemera
+trident::hash::ContentHash                                    // hex, parse
+trident::field::proof::{Claim, padded_height, ...}            // proof sizing
+trident::target::{TerrainConfig, UnionConfig, Arch}
+```
+
+## Feature contract
+
+A warrior takes trident-lang **without default features**:
+
+```toml
+trident-lang = { version = "0.3", default-features = false }
+```
+
+`default = ["neural"]` pulls burn and the cubecl/wgpu graph under it —
+the neural optimizer, which is a compiler-side tool. A warrior never
+trains, so it never needs that graph, and dropping it cuts the
+dependency tree to a fraction. Everything in this document is available
+without default features.
+
+## Stability
+
+- The paths above follow semver on `trident-lang`. Breaking them is a
+  major bump with a CHANGELOG entry naming the warrior-visible change.
+- `TIROp` is an **in-process** contract: a Rust type, not a wire format.
+  A warrior links the same `trident-lang` build it compiles against.
+  Serialization is deliberately absent — the day a non-Rust warrior
+  exists, it gets a defined encoding and a version tag; until then a
+  schema would be a promise with no reader.
+- `ProgramBundle` **does** have a wire form (JSON) because it crosses
+  the process boundary in `trident run/prove/verify`. Fields are
+  additive and `from_json` ignores keys it does not know. It is also
+  lossy today: the `functions` array and the cost table values/names do
+  not survive a round trip (they are re-derived, not read back). A
+  warrior that needs them must take the bundle in memory from
+  `compile_to_bundle`, not through JSON.
+- Everything else in `trident-lang` is internal. Depending on it is
+  allowed and unsupported: it moves without notice.
+
+## Warriors today
+
+| warrior | battlefield | uses |
+|---|---|---|
+| [joy](https://github.com/cyberia-to/joy) | nox · cyber | `runtime::*`, `target`, `field::proof` — takes the bundle, executes on cyber-nox, proves with zheng |
+| [trisha](https://github.com/cyberia-to/trisha) | Triton VM · Neptune | `runtime::*`, `target`, `hash::content_hash_bytes`, `field::proof` — takes the bundle's TASM, executes and proves on Triton VM |
+
+Neither takes TIR yet: today the core lowers to TASM and hands over
+finished assembly. Moving the Triton lowering into trisha — so the core
+stops at TIR for stack targets — is the next step
+(`.claude/plans/warrior-owns-lowering.md`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,11 @@ pub use verify::synthesize;
 // Re-export public API — preserves `trident::compile()` etc.
 pub use api::*;
 
-use diagnostic::{render_diagnostics, Diagnostic};
+// The error type every compilation entry point returns. `use` below is
+// private, so without this a warrior cannot name it (reference/warrior-api.md).
+pub use diagnostic::Diagnostic;
+
+use diagnostic::render_diagnostics;
 use lexer::Lexer;
 use parser::Parser;
 

--- a/tests/warrior_api.rs
+++ b/tests/warrior_api.rs
@@ -1,0 +1,202 @@
+// ---
+// tags: trident, rust, test
+// crystal-type: source
+// crystal-domain: comp
+// ---
+//! The warrior API contract, executable.
+//!
+//! `reference/warrior-api.md` promises a surface that warriors (joy,
+//! trisha) may depend on, available **without default features**. This
+//! test touches every path that document names, so the promise breaks
+//! here — loudly, in CI — rather than in a warrior's build.
+//!
+//! Run both ways:
+//! ```text
+//! cargo test --test warrior_api
+//! cargo test --test warrior_api --no-default-features
+//! ```
+
+use std::path::Path;
+
+use trident::runtime::{
+    Deployer, ExecutionResult, Guesser, ProgramBundle, ProgramInput, Prover, Runner, Verifier,
+};
+use trident::target::{Arch, TerrainConfig};
+use trident::CompileOptions;
+
+/// Every documented compilation entry point exists with the documented
+/// shape. Typed, not called: the point is the signature.
+#[allow(dead_code)]
+fn compilation_surface_is_typed_as_documented() {
+    let _bundle: fn(&Path, &CompileOptions) -> Result<ProgramBundle, Vec<trident::Diagnostic>> =
+        trident::compile_to_bundle;
+    let _tir: fn(
+        &str,
+        &str,
+        &CompileOptions,
+    ) -> Result<Vec<trident::tir::TIROp>, Vec<trident::Diagnostic>> = trident::build_tir;
+    let _tir_project: fn(
+        &Path,
+        &CompileOptions,
+    ) -> Result<Vec<trident::tir::TIROp>, Vec<trident::Diagnostic>> = trident::build_tir_project;
+}
+
+#[test]
+fn compile_options_default_carries_a_terrain() {
+    let options = CompileOptions::default();
+    assert!(!options.target_config.name.is_empty());
+    assert!(!options.profile.is_empty());
+}
+
+#[test]
+fn both_built_in_terrains_resolve_without_a_target_toml() {
+    let nox = TerrainConfig::nox();
+    let triton = TerrainConfig::triton();
+    assert_eq!(nox.name, "nox");
+    assert_eq!(triton.name, "triton");
+    assert_eq!(nox.architecture, Arch::Tree);
+    assert_eq!(triton.architecture, Arch::Stack);
+}
+
+#[test]
+fn a_warrior_can_build_tir_for_a_stack_terrain() {
+    let source = "program w\n\nfn main() -> Field {\n    let a: Field = 6\n    a * 7\n}\n";
+    let mut options = CompileOptions::default();
+    options.target_config = TerrainConfig::triton();
+    let ir = trident::build_tir(source, "w.tri", &options).expect("TIR for a stack terrain");
+    assert!(!ir.is_empty(), "a non-empty program lowers to non-empty TIR");
+}
+
+#[test]
+fn content_hash_is_stable_and_hex_round_trips() {
+    let digest = trident::hash::content_hash_bytes(b"warrior");
+    let hex = trident::hash::ContentHash(digest).to_hex();
+    assert_eq!(hex.len(), 64);
+    assert_eq!(
+        trident::hash::ContentHash::from_hex(&hex).map(|h| h.0),
+        Some(digest)
+    );
+    assert_eq!(trident::hash::content_hash_bytes(b"warrior"), digest);
+}
+
+#[test]
+fn proof_sizing_helpers_are_reachable() {
+    let padded = trident::field::proof::padded_height(1000);
+    assert!(padded >= 1000 && padded.is_power_of_two());
+}
+
+#[test]
+fn bundle_json_round_trip_keeps_what_the_reference_promises() {
+    let bundle = ProgramBundle {
+        name: "w".into(),
+        version: "0.1.0".into(),
+        target_vm: "triton".into(),
+        target_os: None,
+        assembly: "halt".into(),
+        entry_point: "w__main".into(),
+        functions: Vec::new(),
+        cost: trident::runtime::artifact::BundleCost {
+            table_values: Vec::new(),
+            table_names: Vec::new(),
+            padded_height: 256,
+            estimated_proving_ns: 1,
+        },
+        source_hash: "ab".repeat(32),
+        reads_state: true,
+    };
+    let back = ProgramBundle::from_json(&bundle.to_json()).expect("bundle round trip");
+    assert_eq!(back.name, bundle.name);
+    assert_eq!(back.assembly, bundle.assembly);
+    assert_eq!(back.target_vm, bundle.target_vm);
+    assert_eq!(back.entry_point, bundle.entry_point);
+    assert_eq!(back.source_hash, bundle.source_hash);
+    assert_eq!(back.reads_state, bundle.reads_state);
+    assert_eq!(back.cost.padded_height, bundle.cost.padded_height);
+}
+
+#[test]
+fn an_unknown_json_key_does_not_break_a_warrior() {
+    let json = r#"{"name":"w","version":"0.1.0","target_vm":"nox","entry_point":"w__main",
+        "source_hash":"00","assembly":"[1 5]","future_field":"a later trident wrote this"}"#;
+    let bundle = ProgramBundle::from_json(json).expect("unknown keys are ignored");
+    assert_eq!(bundle.name, "w");
+    assert_eq!(bundle.assembly, "[1 5]");
+}
+
+/// The five warrior traits exist and are implementable outside the core.
+/// A warrior implements the ones its battlefield supports.
+struct StubWarrior;
+
+impl Runner for StubWarrior {
+    fn run(&self, _b: &ProgramBundle, _i: &ProgramInput) -> Result<ExecutionResult, String> {
+        Err("stub".into())
+    }
+}
+
+impl Prover for StubWarrior {
+    fn prove(
+        &self,
+        _b: &ProgramBundle,
+        _i: &ProgramInput,
+    ) -> Result<trident::runtime::ProofData, String> {
+        Err("stub".into())
+    }
+}
+
+impl Verifier for StubWarrior {
+    fn verify(&self, _p: &trident::runtime::ProofData) -> Result<bool, String> {
+        Err("stub".into())
+    }
+}
+
+impl Guesser for StubWarrior {
+    fn guess(
+        &self,
+        _b: &ProgramBundle,
+        _i: &ProgramInput,
+        _difficulty: u64,
+        _max_attempts: u64,
+    ) -> Result<trident::runtime::GuessResult, String> {
+        Err("stub".into())
+    }
+}
+
+impl Deployer for StubWarrior {
+    fn deploy(
+        &self,
+        _b: &ProgramBundle,
+        _proof: Option<&trident::runtime::ProofData>,
+    ) -> Result<String, String> {
+        Err("stub".into())
+    }
+}
+
+#[test]
+fn the_warrior_traits_are_implementable_from_outside() {
+    let w = StubWarrior;
+    let input = ProgramInput {
+        public: vec![1],
+        secret: vec![],
+        digests: vec![],
+    };
+    let bundle = ProgramBundle {
+        name: "w".into(),
+        version: String::new(),
+        target_vm: "nox".into(),
+        target_os: None,
+        assembly: "[1 5]".into(),
+        entry_point: String::new(),
+        functions: Vec::new(),
+        cost: trident::runtime::artifact::BundleCost {
+            table_values: Vec::new(),
+            table_names: Vec::new(),
+            padded_height: 0,
+            estimated_proving_ns: 0,
+        },
+        source_hash: String::new(),
+        reads_state: false,
+    };
+    assert!(w.run(&bundle, &input).is_err(), "the stub refuses, by design");
+    let _: &dyn Guesser = &w as &dyn Guesser;
+    let _: &dyn Deployer = &w as &dyn Deployer;
+}


### PR DESCRIPTION
reference/warrior-api.md states what a warrior may link from
trident-lang: compile_to_bundle, build_tir/build_tir_project, the
runtime types and traits, TerrainConfig, content hashing, proof sizing —
plus the feature contract (`default-features = false`: a warrior never
trains, so burn/cubecl/wgpu stay out of its graph) and the stability
promise (semver on those paths; TIR is an in-process Rust contract, not
a wire format; ProgramBundle's JSON is the only crossing format, and its
round trip is lossy in a documented way).

tests/warrior_api.rs makes the document executable — it touches every
path the reference names and runs in both feature configurations, so
the promise breaks in CI rather than in a warrior's build.

Writing that test immediately found a real hole: `Diagnostic` — the
error type EVERY documented entry point returns — was unreachable as
`trident::Diagnostic` because lib.rs imported it privately. Now
re-exported at the crate root.

The plan's other S2 item, a `neural::Target` trait, is deliberately not
here: it would be an abstraction with exactly one implementation, which
reference/quality.md pass 10 forbids. It belongs with the code that
moves in S3 (vocab.rs 449 + grammar 721 + stack_verifier 1170 LOC of
TASM knowledge), where the second implementation makes it earn its
place.

Verified: 1039 tests green (8 new), zero warnings with and without
default features.
