### PR TITLE
feat: build_tir_modules — per-module TIR, the warrior lowering contract (S3)

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -447,6 +447,69 @@ pub fn build_tir(
     Ok(optimize_tir(ir))
 }
 
+/// One module's TIR, with the metadata a warrior needs to lower and link it.
+///
+/// `build_tir_project` concatenates modules, which is what the neural
+/// optimizer wants; a warrior that emits its own assembly needs the
+/// boundaries back — labels are mangled per module and exactly one module
+/// is the program (its entry point is the linked program's entry point).
+#[derive(Clone, Debug)]
+pub struct ModuleTir {
+    /// Module name as declared in `program <name>` / `module <name>`.
+    pub name: String,
+    /// True for the `program` module — the linked program's entry.
+    pub is_program: bool,
+    /// Typed, optimized TIR for this module alone.
+    pub ops: Vec<crate::tir::TIROp>,
+}
+
+/// Build per-module TIR for a project — the warrior lowering contract.
+///
+/// The core stops here for a warrior that owns its target's assembly:
+/// it hands over typed, optimized, monomorphized TIR with module
+/// boundaries intact, and the warrior turns each module into its ISA and
+/// links them. See `reference/warrior-api.md`.
+pub fn build_tir_modules(
+    entry_path: &Path,
+    options: &CompileOptions,
+) -> Result<Vec<ModuleTir>, Vec<Diagnostic>> {
+    use crate::pipeline::PreparedProject;
+
+    let project = PreparedProject::build(entry_path, options)?;
+
+    let intrinsic_map = project.intrinsic_map();
+    let module_aliases = project.module_aliases();
+    let external_constants = project.external_constants();
+
+    let mut modules = Vec::new();
+    for (i, pm) in project.modules.iter().enumerate() {
+        let mono = project
+            .exports
+            .get(i)
+            .map(|e| e.mono_instances.clone())
+            .unwrap_or_default();
+        let call_res = project
+            .exports
+            .get(i)
+            .map(|e| e.call_resolutions.clone())
+            .unwrap_or_default();
+        let ir = TIRBuilder::new(options.target_config.clone())
+            .with_cfg_flags(options.cfg_flags.clone())
+            .with_intrinsics(intrinsic_map.clone())
+            .with_module_aliases(module_aliases.clone())
+            .with_constants(external_constants.clone())
+            .with_mono_instances(mono)
+            .with_call_resolutions(call_res)
+            .build_file(&pm.file);
+        modules.push(ModuleTir {
+            name: pm.file.name.node.clone(),
+            is_program: pm.file.kind == FileKind::Program,
+            ops: optimize_tir(ir),
+        });
+    }
+    Ok(modules)
+}
+
 /// Build TIR from a project entry point with full module resolution.
 ///
 /// Uses the same multi-module pipeline as `compile_project_with_options`

--- a/src/ir/tir/linker.rs
+++ b/src/ir/tir/linker.rs
@@ -5,19 +5,19 @@
 // ---
 /// Per-module TASM output ready for linking.
 #[derive(Clone, Debug)]
-pub(crate) struct ModuleTasm {
+pub struct ModuleTasm {
     /// Dotted module name (e.g. "merkle").
-    pub(crate) module_name: String,
+    pub module_name: String,
     /// Whether this is the program entry module.
-    pub(crate) is_program: bool,
+    pub is_program: bool,
     /// Raw TASM output from the emitter.
-    pub(crate) tasm: String,
+    pub tasm: String,
 }
 
 /// Link multiple module TASM outputs into a single program.
 /// Performs dead code elimination: only includes functions reachable
 /// from the program entry point.
-pub(crate) fn link(modules: Vec<ModuleTasm>) -> String {
+pub fn link(modules: Vec<ModuleTasm>) -> String {
     // First, mangle all modules and collect the full TASM.
     let mut all_lines = Vec::new();
 

--- a/src/ir/tir/mod.rs
+++ b/src/ir/tir/mod.rs
@@ -11,7 +11,10 @@
 
 pub mod builder;
 pub mod encode;
-pub(crate) mod linker;
+/// TASM label mangling and module linking. Public because a warrior that
+/// owns its lowering also owns linking (reference/warrior-api.md); this
+/// moves to trisha with the Triton lowering.
+pub mod linker;
 pub mod lower;
 pub mod neural;
 pub(crate) mod optimize;


### PR DESCRIPTION
A warrior that emits its own assembly needs what build_tir_project
throws away: module boundaries. Labels are mangled per module and
exactly one module is the program, so a flat op list cannot be linked.

`trident::build_tir_modules(entry, options) -> Vec<ModuleTir>` hands
over typed, optimized, monomorphized TIR with `name` and `is_program`
intact — the point where the core stops for a stack target and the
warrior takes over. `tir::linker` (link + ModuleTasm) becomes public
for the same reason: a warrior that owns lowering also owns linking.
Both move to trisha when the Triton lowering does; until then they are
the seam that lets trisha build for real (trisha's
rs/tests/build_matches_trident.rs pins its output byte-identical to
`trident build --target triton`).

No behaviour change in the core: compile_project_with_options still
lowers and links exactly as before. 1039 tests green, zero warnings
with and without default features.
