### PR TITLE
feat!: the library default terrain is nox, like the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Lower is colder. Colder is more stable.
 
 ## Unreleased
 
+- **BREAKING (library): the default terrain is nox.** The CLI has
+  defaulted to nox since 0.2.0, but `CompileOptions::default()` and
+  `::for_profile()` still handed back Triton — so `trident::compile()`,
+  the crate's front door, emitted TASM while `trident build` emitted a
+  nox formula. The library now follows the CLI: default = nox, the
+  terrain the stack runs and proves on (joy + zheng). A caller who wants
+  a stack engine names it (`options.target_config =
+  TerrainConfig::triton()`), which is also what the ~110 TASM-asserting
+  tests now do — they say which engine they test instead of leaning on a
+  default, so they keep saying it when the Triton lowering moves to
+  trisha. The same fix landed in trisha, where it was a real bug: the
+  Triton warrior inherited whatever the compiler defaulted to instead of
+  naming its own terrain.
 - **`neural` is a default-on feature.** burn (and the cubecl/wgpu graph
   under it) is the heaviest thing trident links. The compiler binary is
   unchanged; `--no-default-features` gives a light library build for

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,11 +37,15 @@ pub struct CompileOptions {
 }
 
 impl Default for CompileOptions {
+    /// Defaults to **nox** — the same terrain the CLI defaults to since
+    /// 0.2.0, and the one the stack proves on (joy + zheng). A caller who
+    /// wants a foreign engine names it: `options.target_config =
+    /// TerrainConfig::triton()`, or resolve one from `vm/<engine>/target.toml`.
     fn default() -> Self {
         Self {
             profile: "debug".to_string(),
             cfg_flags: BTreeSet::from(["debug".to_string()]),
-            target_config: TerrainConfig::triton(),
+            target_config: TerrainConfig::nox(),
             dep_dirs: Vec::new(),
         }
     }
@@ -49,11 +53,13 @@ impl Default for CompileOptions {
 
 impl CompileOptions {
     /// Create options for a named profile (debug/release/custom).
+    ///
+    /// Terrain is nox, as in [`Default`].
     pub fn for_profile(profile: &str) -> Self {
         Self {
             profile: profile.to_string(),
             cfg_flags: BTreeSet::from([profile.to_string()]),
-            target_config: TerrainConfig::triton(),
+            target_config: TerrainConfig::nox(),
             dep_dirs: Vec::new(),
         }
     }
@@ -64,7 +70,10 @@ impl CompileOptions {
     }
 }
 
-/// Compile a single Trident source string to TASM.
+/// Compile a single Trident source string for the default terrain (nox).
+///
+/// Returns a nox formula in bracket notation. For a stack engine, use
+/// [`compile_with_options`] with an explicit `target_config`.
 pub fn compile(source: &str, filename: &str) -> Result<String, Vec<Diagnostic>> {
     compile_with_options(source, filename, &CompileOptions::default())
 }

--- a/src/api/tests/check.rs
+++ b/src/api/tests/check.rs
@@ -90,7 +90,7 @@ fn test_discover_tests_empty_when_no_tests() {
 fn test_test_fn_compiles_normally() {
     // #[test] functions should be accepted but skipped during normal emit
     let source = "program test\n#[test]\nfn check() {\n    assert(true)\n}\nfn main() {\n    pub_write(pub_read())\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "program with test fn should compile: {:?}",

--- a/src/api/tests/compile.rs
+++ b/src/api/tests/compile.rs
@@ -3,13 +3,12 @@
 // crystal-type: source
 // crystal-domain: comp
 // ---
-use crate::*;
 
 #[test]
 fn test_compile_valid_program() {
     let source =
         "program test\nfn main() {\n    let x: Field = pub_read()\n    pub_write(x + 1)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_ok());
     let tasm = result.unwrap();
     assert!(tasm.contains("read_io 1"));
@@ -19,7 +18,7 @@ fn test_compile_valid_program() {
 #[test]
 fn test_compile_type_error_returns_err() {
     let source = "program test\nfn main() {\n    let x: U32 = pub_read()\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_err());
 }
 
@@ -41,7 +40,7 @@ if x == 0 {
 }
 }
 "#;
-    assert!(compile(source, "test.tri").is_ok());
+    assert!(super::compile_triton(source, "test.tri").is_ok());
 }
 
 #[test]
@@ -59,7 +58,7 @@ for i in 0..3 bounded 3 {
 pub_write(s)
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_ok());
     let tasm = result.unwrap();
     assert!(tasm.contains("write_io 1"));
@@ -91,7 +90,7 @@ let r: Field = pub_read()
 pub_write(a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r)
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "should handle 18 live variables with spilling"
@@ -124,7 +123,7 @@ let x: Field = pub_read()
 pub_write(add4(add4(x)))
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_ok());
 }
 
@@ -146,7 +145,7 @@ pub_write(sum)
 pub_write(prod)
 }
 "#;
-    assert!(compile(source, "test.tri").is_ok());
+    assert!(super::compile_triton(source, "test.tri").is_ok());
 }
 
 #[test]
@@ -163,7 +162,7 @@ let auth: AuthData = AuthData { owner: d, nonce: 42 }
 pub_write(auth.nonce)
 }
 "#;
-    assert!(compile(source, "test.tri").is_ok());
+    assert!(super::compile_triton(source, "test.tri").is_ok());
 }
 
 #[test]
@@ -178,7 +177,7 @@ let d: XField = xinvert(c)
 pub_write(0)
 }
 "#;
-    assert!(compile(source, "test.tri").is_ok());
+    assert!(super::compile_triton(source, "test.tri").is_ok());
 }
 
 #[test]
@@ -192,7 +191,7 @@ fn main() {
 pub_write(double(pub_read()))
 }
 "#;
-    assert!(compile(source, "test.tri").is_ok());
+    assert!(super::compile_triton(source, "test.tri").is_ok());
 }
 
 #[test]
@@ -209,7 +208,7 @@ fn main() {
 pub_write(abs_diff(pub_read(), pub_read()))
 }
 "#;
-    assert!(compile(source, "test.tri").is_ok());
+    assert!(super::compile_triton(source, "test.tri").is_ok());
 }
 
 #[test]
@@ -238,7 +237,7 @@ reveal Transfer { from: a, to: b, amount: c }
 seal Commitment { value: a }
 }
 "#;
-    let tasm = compile(source, "events.tri").expect("events program should compile");
+    let tasm = super::compile_triton(source, "events.tri").expect("events program should compile");
 
     // reveal Transfer: push 0, write_io 1, [field], write_io 1 × 3
     // Total write_io 1 from reveal: 4 (tag + 3 fields)
@@ -302,7 +301,7 @@ fn test_coin_compiles() {
     if !path.exists() {
         return;
     }
-    let tasm = compile_project(path).expect("coin program should compile");
+    let tasm = super::compile_project_triton(path).expect("coin program should compile");
 
     // Verify all 5 operations are in the TASM output
     assert!(tasm.contains("__pay:"), "missing pay function");
@@ -374,7 +373,7 @@ fn test_card_compiles() {
     if !path.exists() {
         return;
     }
-    let tasm = compile_project(path).expect("card program should compile");
+    let tasm = super::compile_project_triton(path).expect("card program should compile");
 
     // Verify all 5 PLUMB operations
     assert!(tasm.contains("__pay:"), "missing pay function");

--- a/src/api/tests/cost.rs
+++ b/src/api/tests/cost.rs
@@ -27,7 +27,7 @@ fn test_coin_cost_analysis() {
     if !path.exists() {
         return;
     }
-    let cost = analyze_costs_project(path, &CompileOptions::default())
+    let cost = analyze_costs_project(path, &super::triton_options("debug"))
         .expect("cost analysis should succeed");
 
     // Processor table should be nonzero

--- a/src/api/tests/docs.rs
+++ b/src/api/tests/docs.rs
@@ -15,7 +15,7 @@ fn test_generate_docs_simple() {
     )
     .unwrap();
 
-    let options = CompileOptions::default();
+    let options = super::triton_options("debug");
     let doc = generate_docs(&main_path, &options).expect("doc generation should succeed");
 
     // Should contain the program name as title
@@ -45,7 +45,7 @@ fn test_generate_docs_with_structs() {
     )
     .unwrap();
 
-    let options = CompileOptions::default();
+    let options = super::triton_options("debug");
     let doc = generate_docs(&main_path, &options).expect("doc generation should succeed");
 
     // Should contain struct section
@@ -79,7 +79,7 @@ fn test_generate_docs_with_events() {
     )
     .unwrap();
 
-    let options = CompileOptions::default();
+    let options = super::triton_options("debug");
     let doc = generate_docs(&main_path, &options).expect("doc generation should succeed");
 
     // Should contain events section
@@ -107,7 +107,7 @@ fn test_generate_docs_cost_annotations() {
     )
     .unwrap();
 
-    let options = CompileOptions::default();
+    let options = super::triton_options("debug");
     let doc = generate_docs(&main_path, &options).expect("doc generation should succeed");
 
     // Should contain cost annotations on functions

--- a/src/api/tests/features.rs
+++ b/src/api/tests/features.rs
@@ -19,7 +19,7 @@ let s: Field = first<3>(a)
 pub_write(s)
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "generic fn should compile: {:?}",
@@ -46,7 +46,7 @@ let s: Field = first(a)
 pub_write(s)
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "generic fn with inference should compile: {:?}",
@@ -67,7 +67,7 @@ let a: [Field; 3] = [1, 2, 3]
 let s: Field = first<5>(a)
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_err(), "wrong size arg should fail compilation");
 }
 
@@ -85,7 +85,7 @@ let b: [Field; 5] = [1, 2, 3, 4, 5]
 pub_write(first<3>(a) + first<5>(b))
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "multiple instantiations should compile: {:?}",
@@ -111,7 +111,7 @@ let y: Field = pub_read()
 pub_write(add(x, y))
 }
 "#;
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_ok());
     let tasm = result.unwrap();
     assert!(tasm.contains("call __add"));
@@ -142,7 +142,7 @@ pub_write(s)
 fn test_const_generic_add_expression() {
     // Parameter type uses M + N size expression
     let source = "program test\nfn first_of<M, N>(a: [Field; M + N]) -> Field {\n    a[0]\n}\nfn main() {\n    let a: [Field; 5] = [1, 2, 3, 4, 5]\n    let r = first_of<3, 2>(a)\n    assert(r == 1)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "const generic add should compile: {:?}",
@@ -154,7 +154,7 @@ fn test_const_generic_add_expression() {
 fn test_const_generic_mul_expression() {
     // Parameter type uses N * 2 size expression
     let source = "program test\nfn sum_pairs<N>(a: [Field; N * 2]) -> Field {\n    a[0] + a[1]\n}\nfn main() {\n    let a: [Field; 4] = [1, 2, 3, 4]\n    let r = sum_pairs<2>(a)\n    assert(r == 3)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "const generic mul should compile: {:?}",
@@ -165,7 +165,7 @@ fn test_const_generic_mul_expression() {
 #[test]
 fn test_cfg_debug_compiles() {
     let source = "program test\n#[cfg(debug)]\nfn check() {\n    assert(true)\n}\nfn main() {\n    check()\n}";
-    let options = CompileOptions::for_target("debug");
+    let options = super::triton_options("debug");
     let result = compile_with_options(source, "test.tri", &options);
     assert!(result.is_ok(), "debug cfg should compile in debug mode");
     let tasm = result.unwrap();
@@ -175,7 +175,7 @@ fn test_cfg_debug_compiles() {
 #[test]
 fn test_cfg_release_excludes_debug_fn() {
     let source = "program test\n#[cfg(debug)]\nfn check() {\n    assert(true)\n}\nfn main() {}";
-    let options = CompileOptions::for_target("release");
+    let options = super::triton_options("release");
     let result = compile_with_options(source, "test.tri", &options);
     assert!(result.is_ok(), "should compile without debug fn");
     let tasm = result.unwrap();
@@ -189,11 +189,11 @@ fn test_cfg_release_excludes_debug_fn() {
 fn test_cfg_different_targets_different_output() {
     let source = "program test\n#[cfg(debug)]\nfn mode() -> Field { 0 }\n#[cfg(release)]\nfn mode() -> Field { 1 }\nfn main() {\n    let x: Field = mode()\n    pub_write(x)\n}";
 
-    let debug_opts = CompileOptions::for_target("debug");
+    let debug_opts = super::triton_options("debug");
     let debug_tasm =
         compile_with_options(source, "test.tri", &debug_opts).expect("debug should compile");
 
-    let release_opts = CompileOptions::for_target("release");
+    let release_opts = super::triton_options("release");
     let release_tasm = compile_with_options(source, "test.tri", &release_opts)
         .expect("release should compile");
 
@@ -208,7 +208,7 @@ fn test_cfg_different_targets_different_output() {
 #[test]
 fn test_cfg_const_excluded_in_release() {
     let source = "program test\n#[cfg(debug)]\nconst LEVEL: Field = 3\nfn main() {}";
-    let options = CompileOptions::for_target("release");
+    let options = super::triton_options("release");
     let result = compile_with_options(source, "test.tri", &options);
     assert!(
         result.is_ok(),
@@ -220,14 +220,14 @@ fn test_cfg_const_excluded_in_release() {
 fn test_no_cfg_backward_compatible() {
     // All existing code should work unchanged (no cfg = always active)
     let source = "program test\nfn helper() -> Field { 42 }\nfn main() {\n    let x: Field = helper()\n    pub_write(x)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_ok(), "no-cfg code should compile as before");
 }
 
 #[test]
 fn test_match_compiles() {
     let source = "program test\nfn main() {\n    let x: Field = pub_read()\n    match x {\n        0 => { pub_write(0) }\n        1 => { pub_write(1) }\n        _ => { pub_write(2) }\n    }\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_ok(), "match should compile: {:?}", result.err());
     let tasm = result.unwrap();
     assert!(tasm.contains("eq"), "match should emit equality checks");
@@ -237,7 +237,7 @@ fn test_match_compiles() {
 #[test]
 fn test_match_bool_compiles() {
     let source = "program test\nfn main() {\n    let b: Bool = pub_read() == pub_read()\n    match b {\n        true => { pub_write(1) }\n        false => { pub_write(0) }\n    }\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "bool match should compile: {:?}",
@@ -248,14 +248,14 @@ fn test_match_bool_compiles() {
 #[test]
 fn test_match_non_exhaustive_fails() {
     let source = "program test\nfn main() {\n    let x: Field = pub_read()\n    match x {\n        0 => { pub_write(0) }\n    }\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_err(), "non-exhaustive match should fail");
 }
 
 #[test]
 fn test_match_struct_pattern_compiles() {
     let source = "program test\nstruct Point { x: Field, y: Field }\nfn main() {\n    let p = Point { x: pub_read(), y: pub_read() }\n    match p {\n        Point { x, y } => {\n            pub_write(x)\n            pub_write(y)\n        }\n    }\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "struct pattern should compile: {:?}",
@@ -269,7 +269,7 @@ fn test_match_struct_pattern_compiles() {
 #[test]
 fn test_pure_fn_compiles() {
     let source = "program test\n#[pure]\nfn add(a: Field, b: Field) -> Field {\n    a + b\n}\nfn main() {\n    let x = add(1, 2)\n    assert(x == 3)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_ok(), "pure fn should compile: {:?}", result.err());
 }
 
@@ -280,7 +280,7 @@ fn test_struct_field_assignment_compiles_triton() {
     // the mutability checker as "immutable"). Verify it compiles to TASM
     // with no error marker and a real store (swap/pop), not a silent no-op.
     let source = "program test\nstruct Point { x: Field, y: Field }\nfn main() {\n    let mut p = Point { x: pub_read(), y: pub_read() }\n    p.x = 42\n    pub_write(p.x)\n    pub_write(p.y)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "struct field assignment should compile for triton: {:?}",
@@ -295,7 +295,7 @@ fn test_struct_field_assignment_compiles_triton() {
 fn test_array_element_assignment_compiles_triton() {
     // a[i] = v — array element assignment used to collapse to Place::Var("_error_").
     let source = "program test\nfn main() {\n    let mut a: [Field; 3] = [pub_read(), pub_read(), pub_read()]\n    a[1] = 99\n    pub_write(a[0])\n    pub_write(a[1])\n    pub_write(a[2])\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_ok(),
         "array element assignment should compile for triton: {:?}",
@@ -311,7 +311,7 @@ fn test_field_and_index_assignment_immutable_still_rejected() {
     // Mutability is still enforced through the field path: assigning a field
     // of an immutable binding must error.
     let source = "program test\nstruct Point { x: Field, y: Field }\nfn main() {\n    let p = Point { x: 1, y: 2 }\n    p.x = 5\n    pub_write(p.x)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(
         result.is_err(),
         "assigning a field of an immutable struct must be rejected"
@@ -324,7 +324,7 @@ fn test_os_state_read_still_undefined_on_triton() {
     // must keep its existing "undefined function" diagnostic unchanged.
     let source =
         "program test\nfn main() {\n    let v: Field = os.state.read(1)\n    pub_write(v)\n}";
-    let result = compile(source, "test.tri");
+    let result = super::compile_triton(source, "test.tri");
     assert!(result.is_err(), "os.state.read must not typecheck on triton");
     let msg = format!("{:?}", result.err());
     assert!(msg.contains("undefined function"), "{}", msg);

--- a/src/api/tests/mod.rs
+++ b/src/api/tests/mod.rs
@@ -3,6 +3,39 @@
 // crystal-type: source
 // crystal-domain: comp
 // ---
+use std::path::Path;
+
+use crate::diagnostic::Diagnostic;
+use crate::target::TerrainConfig;
+use crate::CompileOptions;
+
+/// Compile a source string for the **Triton** terrain.
+///
+/// These suites assert on TASM, so they name the engine. `compile()` and
+/// `compile_project()` follow the CLI and default to nox; a test that
+/// wants stack assembly says so, and keeps saying so when the Triton
+/// lowering moves to trisha.
+pub(crate) fn compile_triton(source: &str, filename: &str) -> Result<String, Vec<Diagnostic>> {
+    let mut options = CompileOptions::default();
+    options.target_config = TerrainConfig::triton();
+    crate::compile_with_options(source, filename, &options)
+}
+
+/// Options for the Triton terrain at a named profile — see
+/// [`compile_triton`].
+pub(crate) fn triton_options(profile: &str) -> CompileOptions {
+    let mut options = CompileOptions::for_profile(profile);
+    options.target_config = TerrainConfig::triton();
+    options
+}
+
+/// `compile_project` for the Triton terrain — see [`compile_triton`].
+pub(crate) fn compile_project_triton(entry: &Path) -> Result<String, Vec<Diagnostic>> {
+    let mut options = CompileOptions::default();
+    options.target_config = TerrainConfig::triton();
+    crate::compile_project_with_options(entry, &options)
+}
+
 mod check;
 mod compile;
 mod cost;

--- a/src/api/tests/neptune.rs
+++ b/src/api/tests/neptune.rs
@@ -3,7 +3,6 @@
 // crystal-type: source
 // crystal-domain: comp
 // ---
-use crate::*;
 
 #[test]
 fn test_recursive_verifier_compiles() {
@@ -11,7 +10,7 @@ fn test_recursive_verifier_compiles() {
     if !path.exists() {
         return; // skip if running from different cwd
     }
-    let result = compile_project(path);
+    let result = super::compile_project_triton(path);
     assert!(
         result.is_ok(),
         "recursive verifier should compile: {:?}",
@@ -49,7 +48,7 @@ pub_write(r0)
     std::fs::create_dir_all(&ext_dir).unwrap();
     std::fs::copy("os/neptune/xfield.tri", ext_dir.join("xfield.tri")).unwrap_or_default();
 
-    let result = compile_project(&main_path);
+    let result = super::compile_project_triton(&main_path);
     assert!(
         result.is_ok(),
         "xx_dot_step intrinsic should compile: {:?}",
@@ -85,7 +84,7 @@ pub_write(r0)
     std::fs::create_dir_all(&ext_dir).unwrap();
     std::fs::copy("os/neptune/xfield.tri", ext_dir.join("xfield.tri")).unwrap_or_default();
 
-    let result = compile_project(&main_path);
+    let result = super::compile_project_triton(&main_path);
     assert!(
         result.is_ok(),
         "xb_dot_step intrinsic should compile: {:?}",
@@ -134,7 +133,7 @@ pub_write(r2)
     std::fs::copy("vm/io/io.tri", vm_io.join("io.tri")).unwrap_or_default();
     std::fs::copy("vm/core/assert.tri", vm_core.join("assert.tri")).unwrap_or_default();
 
-    let result = compile_project(&main_path);
+    let result = super::compile_project_triton(&main_path);
     assert!(
         result.is_ok(),
         "xfe_inner_product should compile: {:?}",
@@ -179,7 +178,7 @@ pub_write(r0)
     std::fs::copy("vm/io/io.tri", vm_io.join("io.tri")).unwrap_or_default();
     std::fs::copy("vm/core/assert.tri", vm_core.join("assert.tri")).unwrap_or_default();
 
-    let result = compile_project(&main_path);
+    let result = super::compile_project_triton(&main_path);
     assert!(
         result.is_ok(),
         "xb_inner_product should compile: {:?}",
@@ -221,7 +220,7 @@ proof.verify_inner_proof(4)
     std::fs::copy("vm/io/io.tri", vm_io.join("io.tri")).unwrap_or_default();
     std::fs::copy("vm/core/assert.tri", vm_core.join("assert.tri")).unwrap_or_default();
 
-    let result = compile_project(&main_path);
+    let result = super::compile_project_triton(&main_path);
     assert!(
         result.is_ok(),
         "proof composition should compile: {:?}",
@@ -263,7 +262,7 @@ proof.aggregate_proofs(n, 4)
     std::fs::copy("vm/io/io.tri", vm_io.join("io.tri")).unwrap_or_default();
     std::fs::copy("vm/core/assert.tri", vm_core.join("assert.tri")).unwrap_or_default();
 
-    let result = compile_project(&main_path);
+    let result = super::compile_project_triton(&main_path);
     assert!(
         result.is_ok(),
         "proof aggregation should compile: {:?}",
@@ -282,7 +281,7 @@ fn test_proof_relay_example_compiles() {
     if !path.exists() {
         return;
     }
-    let result = compile_project(path);
+    let result = super::compile_project_triton(path);
     assert!(
         result.is_ok(),
         "proof relay example should compile: {:?}",
@@ -296,7 +295,7 @@ fn test_proof_aggregator_example_compiles() {
     if !path.exists() {
         return;
     }
-    let result = compile_project(path);
+    let result = super::compile_project_triton(path);
     assert!(
         result.is_ok(),
         "proof aggregator example should compile: {:?}",
@@ -310,7 +309,7 @@ fn test_transaction_validation_compiles() {
     if !path.exists() {
         return;
     }
-    let result = compile_project(path);
+    let result = super::compile_project_triton(path);
     assert!(
         result.is_ok(),
         "transaction validation should compile: {:?}",
@@ -335,7 +334,7 @@ fn test_neptune_lock_scripts_compile() {
         if !path.exists() {
             continue;
         }
-        let result = compile_project(path);
+        let result = super::compile_project_triton(path);
         assert!(
             result.is_ok(),
             "{} should compile: {:?}",
@@ -353,7 +352,7 @@ fn test_neptune_type_scripts_compile() {
         if !path.exists() {
             continue;
         }
-        let result = compile_project(path);
+        let result = super::compile_project_triton(path);
         assert!(
             result.is_ok(),
             "{} should compile: {:?}",

--- a/src/api/tests/prove.rs
+++ b/src/api/tests/prove.rs
@@ -8,7 +8,6 @@
 //! Programs that require runtime input (divine/pub_read) are expected to
 //! compile but won't execute without input — we only check compilation here.
 
-use crate::compile_project;
 use std::path::Path;
 
 /// Helper: compile a .tri file and assert it succeeds, returning the TASM.
@@ -17,7 +16,7 @@ fn assert_compiles(path: &str) -> String {
     if !p.exists() {
         panic!("{} does not exist", path);
     }
-    match compile_project(p) {
+    match super::compile_project_triton(p) {
         Ok(tasm) => {
             assert!(!tasm.is_empty(), "{} produced empty TASM", path);
             tasm

--- a/tests/audit_stdlib.rs
+++ b/tests/audit_stdlib.rs
@@ -3,14 +3,22 @@
 // crystal-type: source
 // crystal-domain: comp
 // ---
-use trident::compile_project;
+use trident::target::TerrainConfig;
+use trident::CompileOptions;
 
 /// Helper: write a temp program file in the repo root (so module resolution
 /// finds `std/`, `vm/`, `os/`) and compile it.
+///
+/// Compiles for **Triton**: this suite asserts on TASM. `compile_project`
+/// follows the CLI and defaults to nox, where the stdlib's streaming I/O
+/// (`pub_read`/`pub_write`) has no meaning — a nox program takes its
+/// subject and returns a value.
 fn compile_test_program(name: &str, source: &str) -> String {
     let path = std::path::Path::new(name);
     std::fs::write(path, source).expect("write temp program");
-    let result = compile_project(path);
+    let mut options = CompileOptions::default();
+    options.target_config = TerrainConfig::triton();
+    let result = trident::compile_project_with_options(path, &options);
     std::fs::remove_file(path).ok();
     result.unwrap_or_else(|errs| {
         panic!(


### PR DESCRIPTION
trident build has emitted nox since 0.2.0, but CompileOptions::default()
and ::for_profile() still returned TerrainConfig::triton() — so
trident::compile(), the crate's front door, produced TASM. The default
harness the stack actually runs and proves on (nox + joy + zheng) was
one flag away from every library caller.

Now the library follows the CLI. Callers that want a stack engine name
it, and so do the tests: the ~110 TASM-asserting tests in api::tests and
tests/audit_stdlib.rs go through explicit Triton helpers instead of
leaning on a default. That is the honest shape anyway — a test that
asserts `__check:` is a Triton test — and it keeps them correct when
the Triton lowering moves to trisha.

Verified end to end on the default path: trident build -> nox formula,
joy run -> 42, trident prove -> zheng proof 1393 bytes in 20 ms,
trident verify -> PASS. 1039 tests green, zero warnings with and
without default features.
